### PR TITLE
Compatibility with core changes

### DIFF
--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -30,12 +30,12 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
     render json: { api_key: api_key.key }
   end
 
-  # Preview is used when actively developing a theme, it uses the GET parameter ?preview_theme_key
+  # Preview is used when actively developing a theme, it uses the GET parameter ?preview_theme_id
   def preview
     @theme ||= Theme.find(params[:id])
     raise Discourse::InvalidAccess.new() if !guardian.can_hotlink_user_theme?(@theme)
 
-    redirect_to path("/?preview_theme_key=#{@theme.key}")
+    redirect_to path("/?preview_theme_id=#{@theme.id}")
   end
 
   # Shared preview is used when sharing the theme with others. It is only accessible via POST to avoid
@@ -44,12 +44,12 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
     @theme ||= Theme.find(params[:id])
     raise Discourse::InvalidAccess.new() if !guardian.can_see_user_theme?(@theme)
 
-    redirect_to path('/'), flash: { user_theme_key: @theme.key }
+    redirect_to path('/'), flash: { user_theme_id: @theme.id }
   end
 
   def share_info
-    if params[:theme_key]
-      @theme ||= Theme.find_by(key: params[:theme_key])
+    if params[:theme_id]
+      @theme ||= Theme.find_by(id: params[:theme_id])
     else
       theme_owner = User.find_by(username: params[:username])
 

--- a/assets/javascripts/discourse/routes/theme-share-key.js.es6
+++ b/assets/javascripts/discourse/routes/theme-share-key.js.es6
@@ -4,7 +4,7 @@ import { ajax } from 'discourse/lib/ajax';
 export default Ember.Route.extend({
 
   model(params){
-    return ajax(`/theme/${params.theme_key}.json`).then((response)=>{
+    return ajax(`/theme/${params.theme_id}.json`).then((response)=>{
       return response['theme'];
     });
   },

--- a/assets/javascripts/discourse/theme-creator-share-route-map.js.es6
+++ b/assets/javascripts/discourse/theme-creator-share-route-map.js.es6
@@ -1,4 +1,4 @@
 export default function(){
     this.route('theme-share', {path: 'theme/:username/:slug'});
-    this.route('theme-share-key', {path: 'theme/:theme_key'});
+    this.route('theme-share-key', {path: 'theme/:theme_id'});
 };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Discourse::Application.routes.append do
   mount ::ThemeCreator::Engine, at: "/user_themes"
-  get "theme/:theme_key" => "theme_creator/theme_creator#share_info"
+  get "theme/:theme_id" => "theme_creator/theme_creator#share_info"
   get "theme/:username/:slug" => "theme_creator/theme_creator#share_info", constraints: { username: RouteFormat.username }
   get "u/:username/themes" => "users#index", constraints: { username: RouteFormat.username }
   get "u/:username/themes/:id" => "users#index", constraints: { username: RouteFormat.username }

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,14 +17,14 @@ after_initialize do
     ctx.helpers.preload_script('admin')
   end
 
-  # Override guardian to allow users to preview their own themes using the ?preview_theme_key= variable
-  add_to_class(:guardian, :allow_theme?) do |theme_key|
-    return true if Theme.user_theme_keys.include?(theme_key) # Is a 'user selectable theme'
-    return false if not Theme.theme_keys.include?(theme_key) # Is not a valid theme
+  # Override guardian to allow users to preview their own themes using the ?preview_theme_id= variable
+  add_to_class(:guardian, :allow_theme?) do |theme_id|
+    return true if Theme.user_theme_ids.include?(theme_id) # Is a 'user selectable theme'
+    return false if not Theme.theme_ids.include?(theme_id) # Is not a valid theme
 
     # If you own the theme, you are allowed to view it using GET param
     # Even staff are not allowed to use GET to access other user's themes, to reduce XSS attack risk
-    can_hotlink_user_theme? Theme.find_by(key: theme_key)
+    can_hotlink_user_theme? Theme.find_by(id: theme_id)
   end
 
   add_to_class(:guardian, :can_hotlink_user_theme?) do |theme|
@@ -91,10 +91,10 @@ after_initialize do
     can_view = guardian.can_see_user_theme?(@theme)
 
     if !can_hotlink && can_view
-      redirect_to path("/theme/#{@theme.key}")
+      redirect_to path("/theme/#{@theme.id}")
     else
       raise Discourse::InvalidAccess.new() if !can_hotlink
-      redirect_to path("/?preview_theme_key=#{@theme.key}")
+      redirect_to path("/?preview_theme_id=#{@theme.id}")
     end
   end
 
@@ -121,18 +121,18 @@ after_initialize do
   end
 
   # Allow preview of shared user themes
-  # flash[:user_theme_key] will only be populated after a POST request
+  # flash[:user_theme_id] will only be populated after a POST request
   # after a UI confirmation (theme_creator_controller.rb) to prevent hotlinking
   reloadable_patch do |plugin|
     class ::ApplicationController
       module ThemeCreatorOverrides
         def handle_theme
           super()
-          user_theme_key = flash[:user_theme_key]
-          if user_theme_key &&
-             Theme.theme_keys.include?(user_theme_key) && # Has requested a valid theme
-             guardian.can_see_user_theme?(Theme.find_by(key: user_theme_key))
-            @theme_key = request.env[:resolved_theme_key] = user_theme_key
+          user_theme_id = flash[:user_theme_id]
+          if user_theme_id &&
+             Theme.theme_ids.include?(user_theme_id) && # Has requested a valid theme
+             guardian.can_see_user_theme?(Theme.find_by(id: user_theme_id))
+            @theme_id = request.env[:resolved_theme_id] = user_theme_id
           end
         end
       end

--- a/spec/theme_creator_controller_spec.rb
+++ b/spec/theme_creator_controller_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Theme Creator Controller", type: :request do
 
       it 'can delete theme' do
         delete "/user_themes/#{theme.id}.json"
-        expect(response).to be_success
+        expect(response).to be_successful
         expect { theme.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
 
@@ -117,14 +117,14 @@ RSpec.describe "Theme Creator Controller", type: :request do
             name: "New Theme Title"
           }
         }
-        expect(response).to be_success
+        expect(response).to be_successful
         theme.reload
         expect(theme.name).to eq("New Theme Title")
       end
 
       it 'can create color scheme for theme' do
         post "/user_themes/#{theme.id}/colors.json"
-        expect(response).to be_success
+        expect(response).to be_successful
         theme.reload
         expect(theme.color_schemes.count).to eq(1)
       end
@@ -136,14 +136,14 @@ RSpec.describe "Theme Creator Controller", type: :request do
             colors: []
           }
         }
-        expect(response).to be_success
+        expect(response).to be_successful
         color_scheme.reload
         expect(color_scheme.name).to eq("Some New Name")
       end
 
       it "can delete color scheme" do
         delete "/user_themes/#{theme.id}/colors/#{color_scheme.id}.json"
-        expect(response).to be_success
+        expect(response).to be_successful
         expect { color_scheme.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/user_theme_guardian_spec.rb
+++ b/spec/user_theme_guardian_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe ::Guardian do
 
   describe 'hotlinking protection' do
     it 'allows own themes' do
-      expect(guardian1.allow_theme?(theme.id)).to eq(true)
+      expect(guardian1.allow_themes?(theme.id)).to eq(true)
     end
 
     it 'disallows other themes' do
-      expect(guardian2.allow_theme?(theme.id)).to eq(false)
+      expect(guardian2.allow_themes?(theme.id)).to eq(false)
     end
 
     it 'disallows other themes for admins' do
       # This is to reduce XSS risk
-      expect(adminGuardian.allow_theme?(theme.id)).to eq(false)
+      expect(adminGuardian.allow_themes?(theme.id)).to eq(false)
     end
   end
 

--- a/spec/user_theme_guardian_spec.rb
+++ b/spec/user_theme_guardian_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe ::Guardian do
 
   describe 'hotlinking protection' do
     it 'allows own themes' do
-      expect(guardian1.allow_theme?(theme.key)).to eq(true)
+      expect(guardian1.allow_theme?(theme.id)).to eq(true)
     end
 
     it 'disallows other themes' do
-      expect(guardian2.allow_theme?(theme.key)).to eq(false)
+      expect(guardian2.allow_theme?(theme.id)).to eq(false)
     end
 
     it 'disallows other themes for admins' do
       # This is to reduce XSS risk
-      expect(adminGuardian.allow_theme?(theme.key)).to eq(false)
+      expect(adminGuardian.allow_theme?(theme.id)).to eq(false)
     end
   end
 


### PR DESCRIPTION
`key` column on `themes` table is about to be dropped in core, so we need to stop using it here.

Also `be_success` is deprecated in Rails 5.2 (I think), so I replaced it with `be_successful`