### PR TITLE
FIX: Include color scheme in theme downloads.

### DIFF
--- a/assets/javascripts/discourse/controllers/user-themes-view-modal.js.es6
+++ b/assets/javascripts/discourse/controllers/user-themes-view-modal.js.es6
@@ -22,7 +22,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
       }
     },
     download() {
-      document.location = `${Discourse.BaseUri}/theme/${this.model.user.username}/${this.model.id}/download`;
+      document.location = `${Discourse.BaseUri}/user_themes/${this.model.id}`;
     },
     cancel(){
       this.send('closeModal');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,6 @@ Discourse::Application.routes.append do
   mount ::ThemeCreator::Engine, at: "/user_themes"
   get "theme/:theme_key" => "theme_creator/theme_creator#share_info"
   get "theme/:username/:slug" => "theme_creator/theme_creator#share_info", constraints: { username: RouteFormat.username }
-  get "theme/:username/:id/download" => "theme_creator/theme_creator#show", constraints: { username: RouteFormat.username }
   get "u/:username/themes" => "users#index", constraints: { username: RouteFormat.username }
   get "u/:username/themes/:id" => "users#index", constraints: { username: RouteFormat.username }
   get "u/:username/themes/:theme_id/colors/:color_scheme_id" => "users#index", constraints: { username: RouteFormat.username }

--- a/plugin.rb
+++ b/plugin.rb
@@ -118,6 +118,10 @@ after_initialize do
     class ::Theme
       belongs_to :user
     end
+
+    class ::ThemeWithEmbeddedUploadsSerializer
+      has_one :color_scheme, serializer: ColorSchemeSerializer, embed: :objects
+    end
   end
 
   # Allow preview of shared user themes


### PR DESCRIPTION
Sorry for my mistake, PR #4 didn't include color scheme in theme downloads, which is fixed in this PR.

The color scheme is in format of `{colors: [{name: "primary", hex: "222222", default_hex: "222222"}, {name: "secondary", hex: "ffffff", default_hex: "ffffff"}, ...]}`.