### PR TITLE
FIX: 404 if theme or user does not exist

### DIFF
--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -51,9 +51,9 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
 
   def share_info
     if params[:theme_id]
-      @theme ||= Theme.find_by(id: params[:theme_id])
+      @theme ||= Theme.find(params[:theme_id])
     else
-      theme_owner = User.find_by(username: params[:username])
+      raise Discourse::NotFound unless theme_owner = User.find_by_username(params[:username])
 
       result = PluginStoreRow.where(plugin_name: 'discourse-theme-creator')
         .where("key LIKE ?", "share:#{theme_owner.id}:%")

--- a/spec/theme_creator_controller_spec.rb
+++ b/spec/theme_creator_controller_spec.rb
@@ -53,6 +53,12 @@ RSpec.describe "Theme Creator Controller", type: :request do
       SiteSetting.theme_creator_share_groups = ''
       get "/theme/#{user1.username}/#{theme.share_slug}.json"
       expect(response).to have_http_status(200)
+
+      get "/theme/user-not-found/#{theme.share_slug}.json"
+      expect(response).to have_http_status(404)
+
+      get '/theme/theme-not-found.json'
+      expect(response).to have_http_status(404)
     end
   end
 


### PR DESCRIPTION
```text
NoMethodError (undefined method `id' for nil:NilClass)
/var/www/discourse/plugins/discourse-theme-creator/app/controllers/theme_creator/theme_creator_controller.rb:59:in `share_info'
```

This PR correctly handles nonexistent user/theme  when hitting URLs like:

1. `/theme/user-not-found/valid-slug`
2. `/theme/theme-not-found`

