### PR TITLE
FIX: theme download button is missing from view modal

### DIFF
--- a/app/jobs/scheduled/cleanup_topics.rb
+++ b/app/jobs/scheduled/cleanup_topics.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class CleanupTopics < Jobs::Scheduled
+  class CleanupTopics < ::Jobs::Scheduled
     every 30.minutes
 
     def execute(_args)

--- a/app/jobs/scheduled/cleanup_topics.rb
+++ b/app/jobs/scheduled/cleanup_topics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Jobs
   class CleanupTopics < Jobs::Scheduled
     every 30.minutes

--- a/assets/javascripts/discourse/controllers/user-themes-view-modal.js.es6
+++ b/assets/javascripts/discourse/controllers/user-themes-view-modal.js.es6
@@ -22,7 +22,7 @@ export default Ember.Controller.extend(ModalFunctionality, {
       }
     },
     download() {
-      document.location = `${Discourse.BaseUri}/user_themes/${this.model.id}`;
+      document.location = `${Discourse.BaseUri}/user_themes/${this.model.id}/export`;
     },
     cancel() {
       this.send("closeModal");

--- a/assets/javascripts/discourse/templates/modal/user-themes-view-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/user-themes-view-modal.hbs
@@ -32,7 +32,7 @@
       label="theme_creator.view_theme"
     }}
     {{d-button
-      class="btn-secondary btn-large"
+      class="btn-default btn-large"
       action="download"
       title="theme_creator.download_theme"
       label="theme_creator.download_theme"

--- a/assets/javascripts/discourse/templates/modal/user-themes-view-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/user-themes-view-modal.hbs
@@ -31,13 +31,19 @@
       title="theme_creator.view_theme"
       label="theme_creator.view_theme"
     }}
+    {{d-button
+      class="btn-secondary btn-large"
+      action="download"
+      title="theme_creator.download_theme"
+      label="theme_creator.download_theme"
+    }}
   </p>
-  <form id="view-theme-form" method="post" action="{{postURL}}">
-    <input
-      type="hidden"
-      name="authenticity_token"
-      id="authenticity_token"
-      value="{{session.csrfToken}}"
-    />
+  <form id="view-theme-form"
+        method="post"
+        action="{{postURL}}">
+    <input type="hidden"
+           name="authenticity_token"
+           id="authenticity_token"
+           value="{{session.csrfToken}}" />
   </form>
 {{/d-modal-body}}

--- a/assets/javascripts/discourse/templates/modal/user-themes-view-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/user-themes-view-modal.hbs
@@ -1,25 +1,43 @@
-{{#d-modal-body id="theme-creator-view-modal" title="theme_creator.view_shared_theme"}}
+{{#d-modal-body
+  id="theme-creator-view-modal"
+  title="theme_creator.view_shared_theme"
+}}
   <h1>
     {{model.name}}
   </h1>
   <p>
-  {{avatar model.user avatarTemplatePath="avatar_template" title=user.username imageSize="extra_large"}}
+    {{avatar
+      model.user
+      avatarTemplatePath="avatar_template"
+      title=user.username
+      imageSize="extra_large"
+    }}
   </p>
-  <h3>by {{#if model.user.name}}{{model.user.name}}{{else}}{{model.user.username}}{{/if}}</h3>
-
+  <h3>
+    by
+    {{#if model.user.name}}
+      {{model.user.name}}
+    {{else}}
+      {{model.user.username}}
+    {{/if}}
+  </h3>
   <p>
-  {{i18n 'theme_creator.view_shared_theme_education'}}
+    {{i18n "theme_creator.view_shared_theme_education"}}
   </p>
   <p>
-  {{d-button 
-      class='btn-primary btn-large'
-      action='view'
+    {{d-button
+      class="btn-primary btn-large"
+      action="view"
       title="theme_creator.view_theme"
       label="theme_creator.view_theme"
-      }}
+    }}
   </p>
-
-  <form id="view-theme-form" method='post' action="{{postURL}}">
-    <input type="hidden" name="authenticity_token" id="authenticity_token" value="{{session.csrfToken}}">
+  <form id="view-theme-form" method="post" action="{{postURL}}">
+    <input
+      type="hidden"
+      name="authenticity_token"
+      id="authenticity_token"
+      value="{{session.csrfToken}}"
+    />
   </form>
 {{/d-modal-body}}


### PR DESCRIPTION
This PR reintroduces the download button to view theme modal. 

<img width="250" src="https://user-images.githubusercontent.com/33972521/69152251-0be60a00-0b17-11ea-9eba-8d5906efa95c.png">

There are also a couple of minor fixes like using `frozen_string_literal: true` and ensuring compatibility with the Zeitwerk.