### PR TITLE
UX: Change the label for the CLI button

### DIFF
--- a/assets/javascripts/discourse/templates/user-themes.hbs
+++ b/assets/javascripts/discourse/templates/user-themes.hbs
@@ -15,7 +15,7 @@
    </ul>
    <div class="user-create-theme">
     {{d-button action=(route-action 'installModal') icon="upload" label="theme_creator.install_theme" class="btn-primary"}}
-    {{d-button action=(route-action "editLocalModal") icon="laptop-code" label="theme_creator.cli"}}
+    {{d-button action=(route-action "editLocalModal") icon="laptop-code" label="theme_creator.api_key"}}
    </div>
   </div>
  {{/unless}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -55,7 +55,7 @@ en:
       view_theme: "View Theme"
       download_theme: "Download Theme"
 
-      cli: "CLI"
+      api_key: "API Key"
       edit_local: "Edit Locally"
       edit_local_description: "The <b>Discourse Theme CLI</b> is a console application allowing you to edit a theme on your local computer, and instantly preview changes online. To get started, follow the instructions on <a href='https://meta.discourse.org/t/discourse-theme-cli-console-app-to-help-you-build-themes/82950'>Discourse Meta</a>."
       edit_local_key: "API Key for Theme CLI:"


### PR DESCRIPTION
This PR updates the label for the CLI to something more clearer

before 

<img width="150" src="https://user-images.githubusercontent.com/33972521/101259072-91a81800-3761-11eb-80a8-84e04e365942.png">

after

<img width="150" src="https://user-images.githubusercontent.com/33972521/101259027-63c2d380-3761-11eb-903e-42a8fa021ef9.png">

