### PR TITLE
Revert "FIX: users should able to get local theme changes."

### DIFF
--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -9,7 +9,7 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
 
   before_action :ensure_logged_in, except: [:preview, :share_preview, :share_info]
 
-  before_action :ensure_own_theme, only: [:show, :export, :destroy, :update, :create_color_scheme, :update_color_scheme, :destroy_color_scheme, :update_single_setting, :diff_local_changes]
+  before_action :ensure_own_theme, only: [:show, :export, :destroy, :update, :create_color_scheme, :update_color_scheme, :destroy_color_scheme, :update_single_setting]
 
   skip_before_action :check_xhr, only: [:share_info, :preview, :share_preview]
 

--- a/assets/javascripts/discourse/models/user-theme.js.es6
+++ b/assets/javascripts/discourse/models/user-theme.js.es6
@@ -1,6 +1,3 @@
 import Theme from "admin/models/theme";
-import { url } from "discourse/lib/computed";
 
-export default Theme.extend({
-  diffLocalChangesUrl: url("id", "/user_themes/%@/diff_local_changes"),
-});
+export default Theme.extend({});

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,6 @@ ThemeCreator::Engine.routes.draw do
   get ":id/preview" => "theme_creator#preview"
   get ":id/export" => "theme_creator#export"
   put ":id/setting" => "theme_creator#update_single_setting"
-  get ":id/diff_local_changes" => "theme_creator#diff_local_changes"
 
   # Additional theme endpoints
   post "upload_asset" => "theme_creator#upload_asset"

--- a/spec/theme_creator_controller_spec.rb
+++ b/spec/theme_creator_controller_spec.rb
@@ -48,15 +48,6 @@ RSpec.describe "Theme Creator Controller", type: :request do
     end
   end
 
-  describe '#diff_local_changes' do
-
-    it "should return empty for a default theme" do
-      sign_in(user1)
-      get "/user_themes/#{theme.id}/diff_local_changes.json"
-      expect(response.body).to eq("{}")
-    end
-  end
-
   describe 'share_preview' do
     it "fails to preview other users themes" do
       post "/user_themes/#{theme.id}/view"


### PR DESCRIPTION
`diff_local_changes` has been removed from core in https://github.com/discourse/discourse/pull/11247