### PR TITLE
FIX: theme previews were broken

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -167,7 +167,7 @@ after_initialize do
           if user_theme_id &&
              Theme.theme_ids.include?(user_theme_id) && # Has requested a valid theme
              guardian.can_see_user_theme?(Theme.find_by(id: user_theme_id))
-            @theme_ids = request.env[:resolved_theme_ids] = [user_theme_id]
+            @theme_id = request.env[:resolved_theme_id] = user_theme_id
           end
         end
       end


### PR DESCRIPTION
The theme previews were regressed after this commit in core: https://github.com/discourse/discourse/commit/8e3691d5370bb95d99fe750f46287763721fcc9c