### PR TITLE
FIX: Correctly defer loading of admin locale

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -21,7 +21,7 @@ after_initialize do
   # We're re-using a lot of locale strings from the admin section
   # so we need to load it for non-staff users.
   register_html_builder('server:before-head-close') do |ctx|
-    "<script src='#{ExtraLocalesController.url('admin')}'></script>" +
+    ctx.helpers.preload_script_url ExtraLocalesController.url('admin') +
     ctx.helpers.preload_script('admin') +
     ctx.helpers.discourse_stylesheet_link_tag(:admin)
   end


### PR DESCRIPTION
Core recently added the `defer` attribute to all scripts. We need to apply the same here, so that the locale is loaded after the other core JS files. Using the `preload_script_url` helper will match the core behavior, and automatically includes the `defer` attribute.