### PR TITLE
Show modal when click edit

### DIFF
--- a/assets/javascripts/discourse/templates/user-themes-show.hbs
+++ b/assets/javascripts/discourse/templates/user-themes-show.hbs
@@ -473,7 +473,7 @@
     }}
   {{else if showAdvanced}}
     {{d-button
-      action=(action "editLocalModal")
+      action=(route-action "editLocalModal")
       icon="pencil-alt"
       label="theme_creator.edit_local"
     }}


### PR DESCRIPTION
Clicking on "Edit Locally" shows an error because 

```
An action named 'editLocalModal' was not found
```

This error is shown instead on https://discourse.theme-creator.io

<img width="709" alt="Screenshot 2022-07-21 at 9 20 16 PM" src="https://user-images.githubusercontent.com/1555215/180223599-fa260aac-5816-445e-b3e6-9f86af7e41b5.png">
