### PR TITLE
FIX: Update permissions following core change

### DIFF
--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -6,6 +6,7 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
 
   requires_login(nil) # Override the blanket "require logged in" from the admin controller
   skip_before_action :ensure_staff # Open up to non-staff
+  skip_before_action :ensure_admin
 
   before_action :ensure_logged_in, except: [:preview, :share_preview, :share_info]
 

--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -5,8 +5,7 @@
 class ThemeCreator::ThemeCreatorController < Admin::ThemesController
 
   requires_login(nil) # Override the blanket "require logged in" from the admin controller
-  skip_before_action :ensure_staff # Open up to non-staff
-  skip_before_action :ensure_admin
+  skip_before_action :ensure_admin # Open up to non-staff
 
   before_action :ensure_logged_in, except: [:preview, :share_preview, :share_info]
 


### PR DESCRIPTION
theme-creator has its own security model so we can skip core's admin check