### PR TITLE
FIX: Update permissions following core change (take 2)

### DIFF
--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -5,7 +5,8 @@
 class ThemeCreator::ThemeCreatorController < Admin::ThemesController
 
   requires_login(nil) # Override the blanket "require logged in" from the admin controller
-  skip_before_action :ensure_admin # Open up to non-staff
+  skip_before_action :ensure_staff # Open up to non-staff
+  skip_before_action :ensure_admin
 
   before_action :ensure_logged_in, except: [:preview, :share_preview, :share_info]
 


### PR DESCRIPTION
Followup to 985d3ddc. `ensure_staff` is still being used, so we need to skip that as well