### PR TITLE
UX: fix theme actions buttons position alignment

### DIFF
--- a/assets/javascripts/discourse/templates/user-themes-show.hbs
+++ b/assets/javascripts/discourse/templates/user-themes-show.hbs
@@ -447,62 +447,63 @@
       </div>
     {{/if}}
   {{/if}}
+  <div class="theme-controls">
+    {{#if quickColorScheme}}
+      {{#d-button
+        action=(action "saveQuickColorScheme")
+        class="btn btn-primary"
+        disabled=isSaving
+      }}
+        {{saveButtonText}}
+      {{/d-button}}
+    {{/if}}
 
-  {{#if quickColorScheme}}
-    {{#d-button
-      action=(action "saveQuickColorScheme")
-      class="btn btn-primary"
-      disabled=isSaving
-    }}
-      {{saveButtonText}}
-    {{/d-button}}
-  {{/if}}
-
-  {{d-button
-    action=(action "shareModal")
-    label="theme_creator.share"
-    icon="users"
-    class="btn-primary"
-  }}
-
-  {{#if quickColorScheme}}
     {{d-button
-      action=(action "showAdvanced")
-      icon="cog"
-      label="theme_creator.show_advanced"
+      action=(action "shareModal")
+      label="theme_creator.share"
+      icon="users"
+      class="btn-primary"
     }}
-  {{else if showAdvanced}}
-    {{d-button
-      action=(route-action "editLocalModal")
-      icon="pencil-alt"
-      label="theme_creator.edit_local"
-    }}
-  {{/if}}
 
-  {{#unless hidePreview}}
-    <a
-      href={{previewUrl}}
-      title={{i18n "theme_creator.explain_preview"}}
-      class="btn btn-icon-text"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      {{d-icon "desktop"}}
-      <span class="d-button-label">
-        {{i18n "theme_creator.preview"}}
-      </span>
+    {{#if quickColorScheme}}
+      {{d-button
+        action=(action "showAdvanced")
+        icon="cog"
+        label="theme_creator.show_advanced"
+      }}
+    {{else if showAdvanced}}
+      {{d-button
+        action=(route-action "editLocalModal")
+        icon="pencil-alt"
+        label="theme_creator.edit_local"
+      }}
+    {{/if}}
+
+    {{#unless hidePreview}}
+      <a
+        href={{previewUrl}}
+        title={{i18n "theme_creator.explain_preview"}}
+        class="btn btn-icon-text"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {{d-icon "desktop"}}
+        <span class="d-button-label">
+          {{i18n "theme_creator.preview"}}
+        </span>
+      </a>
+    {{/unless}}
+
+    <a href={{downloadUrl}} class="btn" target="_blank" rel="noopener noreferrer">
+      {{d-icon "download"}}
+      {{i18n "admin.export_json.button_text"}}
     </a>
-  {{/unless}}
 
-  <a href={{downloadUrl}} class="btn" target="_blank" rel="noopener noreferrer">
-    {{d-icon "download"}}
-    {{i18n "admin.export_json.button_text"}}
-  </a>
-
-  {{d-button
-    action=(action "destroy")
-    label="theme_creator.delete"
-    icon="trash-alt"
-    class="btn btn-danger"
-  }}
+    {{d-button
+      action=(action "destroy")
+      label="theme_creator.delete"
+      icon="trash-alt"
+      class="btn btn-danger"
+    }}
+  </div>
 </div>

--- a/assets/javascripts/discourse/templates/user-themes-show.hbs
+++ b/assets/javascripts/discourse/templates/user-themes-show.hbs
@@ -494,7 +494,12 @@
       </a>
     {{/unless}}
 
-    <a href={{downloadUrl}} class="btn" target="_blank" rel="noopener noreferrer">
+    <a
+      href={{downloadUrl}}
+      class="btn"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       {{d-icon "download"}}
       {{i18n "admin.export_json.button_text"}}
     </a>

--- a/assets/stylesheets/theme-creator.scss
+++ b/assets/stylesheets/theme-creator.scss
@@ -171,6 +171,13 @@
       width: 650px;
       max-width: 100%;
     }
+
+    .theme-controls {
+      clear: left;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+    }
   }
 
   .status-message {


### PR DESCRIPTION
I'm using the same HTML code as in the regular admin -> customize -> themes page to wrap the button, with additional CSS for the theme creator.

Before:
<img width="866" alt="Screenshot 2023-04-27 at 13 30 56" src="https://user-images.githubusercontent.com/5654300/234854290-89a69514-7139-422e-9a93-d1c8485a385c.png">

<img width="665" alt="Screenshot 2023-04-27 at 13 36 08" src="https://user-images.githubusercontent.com/5654300/234854330-76799322-b85b-40b5-a6ea-862d20a1e724.png">

After:
<img width="672" alt="Screenshot 2023-04-27 at 13 43 56" src="https://user-images.githubusercontent.com/5654300/234854370-f5a4de82-505e-4bbb-a9a0-f39b99b8f3a5.png">

<img width="670" alt="Screenshot 2023-04-27 at 13 45 33" src="https://user-images.githubusercontent.com/5654300/234854386-c6b39503-c80d-4004-a8a7-9652066dda0e.png">

