### PR TITLE
UX: fix empty space in the share URL

### DIFF
--- a/assets/javascripts/discourse/templates/modal/user-themes-share-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/user-themes-share-modal.hbs
@@ -44,8 +44,7 @@
         }}
       {{else}}
         <code>
-          {{model.base_share_url}}
-          {{model.share_slug}}
+          {{model.base_share_url}}{{model.share_slug}}
           <a href {{action "startEditingSlug"}}>{{d-icon "pencil-alt"}}</a>
         </code>
 


### PR DESCRIPTION
Remove an empty space in the share URL that prevents copy-pasting a valid share link.

Before:
![image](https://github.com/discourse/discourse-theme-creator/assets/5654300/8bf5390a-8158-4ae4-bc95-45f8b4c14650)

After:
![image](https://github.com/discourse/discourse-theme-creator/assets/5654300/49c81779-1492-46f5-954f-a7a0dbb08265)
