### PR TITLE
UX: Fix theme settings layout

### DIFF
--- a/assets/javascripts/discourse/templates/modal/user-themes-share-modal.hbs
+++ b/assets/javascripts/discourse/templates/modal/user-themes-share-modal.hbs
@@ -44,8 +44,7 @@
         }}
       {{else}}
         <code>
-          {{model.base_share_url}}
-          {{model.share_slug}}
+          {{model.base_share_url}}{{model.share_slug}}
           <a href {{action "startEditingSlug"}}>{{d-icon "pencil-alt"}}</a>
         </code>
 

--- a/assets/stylesheets/theme-creator.scss
+++ b/assets/stylesheets/theme-creator.scss
@@ -121,6 +121,12 @@
     display: block;
     width: 100%;
 
+    .row:after {
+      clear: left;
+      display: table;
+      content: "";
+    }
+
     .btn {
       line-height: $line-height-medium; // Temporary button-height fix
     }


### PR DESCRIPTION
Fixes the theme settings layout.

Before:
![image](https://github.com/discourse/discourse-theme-creator/assets/5654300/5c96258c-1f28-4b40-ac24-36a98aaeec60)

After:
![image](https://github.com/discourse/discourse-theme-creator/assets/5654300/777c46a7-a57c-4cab-af5a-bbedc64f2886)
