### PR TITLE
FIX: ensures stop sharing is working

### DIFF
--- a/assets/javascripts/discourse/components/modal/user-themes-share-modal.js
+++ b/assets/javascripts/discourse/components/modal/user-themes-share-modal.js
@@ -37,7 +37,7 @@ export default class UserThemesShareModal extends Component {
 
   @action
   stopSharing() {
-    this.set("model.share_slug", null);
+    this.args.model.set("share_slug", null);
     this.args.model.saveChanges("share_slug");
   }
 


### PR DESCRIPTION
A refactor done in https://github.com/discourse/discourse-theme-creator/commit/1f24a3783875b9313f42341fb70f579e91d0a296 hasn't correctly converted this line as it was now acting as if `model` was a property on `this` and not `this.args` which is incorrect.