### PR TITLE
FIX: ensures users can edit settings

### DIFF
--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -20,6 +20,7 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
                   update_color_scheme
                   destroy_color_scheme
                   update_single_setting
+                  objects_setting_metadata
                 ]
 
   skip_before_action :check_xhr, only: %i[share_info preview share_preview]
@@ -239,6 +240,16 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
 
   def ban_for_remote_theme!
     # no-op - we want to allow this stuff for theme-creator
+  end
+
+  def objects_setting_metadata
+    theme = Theme.find_by(id: params[:id])
+    raise Discourse::InvalidParameters.new(:id) unless theme
+
+    theme_setting = theme.settings[params[:setting_name].to_sym]
+    raise Discourse::InvalidParameters.new(:setting_name) unless theme_setting
+
+    render_serialized(theme_setting, ThemeObjectsSettingMetadataSerializer, root: false)
   end
 
   private

--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -242,16 +242,6 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
     # no-op - we want to allow this stuff for theme-creator
   end
 
-  def objects_setting_metadata
-    theme = Theme.find_by(id: params[:id])
-    raise Discourse::InvalidParameters.new(:id) unless theme
-
-    theme_setting = theme.settings[params[:setting_name].to_sym]
-    raise Discourse::InvalidParameters.new(:setting_name) unless theme_setting
-
-    render_serialized(theme_setting, ThemeObjectsSettingMetadataSerializer, root: false)
-  end
-
   private
 
   # Override with a restricted version

--- a/assets/javascripts/discourse/components/user-schema-theme-setting-editor.gjs
+++ b/assets/javascripts/discourse/components/user-schema-theme-setting-editor.gjs
@@ -1,0 +1,26 @@
+import { action } from "@ember/object";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import SchemaThemeSettingEditor from "admin/components/schema-theme-setting/editor";
+
+export default class UserSchemaThemeSettingEditor extends SchemaThemeSettingEditor {
+  @action
+  saveChanges() {
+    this.saveButtonDisabled = true;
+
+    this.args.setting
+      .updateSetting(this.args.themeId, this.data)
+      .then((result) => {
+        this.args.setting.set("value", result[this.args.setting.setting]);
+
+        this.router.transitionTo("user.themes.show", this.args.themeId);
+      })
+      .catch((e) => {
+        if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {
+          this.validationErrorMessage = e.jqXHR.responseJSON.errors[0];
+        } else {
+          popupAjaxError(e);
+        }
+      })
+      .finally(() => (this.saveButtonDisabled = false));
+  }
+}

--- a/assets/javascripts/discourse/components/user-theme-setting-editor.js
+++ b/assets/javascripts/discourse/components/user-theme-setting-editor.js
@@ -1,6 +1,39 @@
-import { url } from "discourse/lib/computed";
+import JsonSchemaEditorModal from "discourse/components/modal/json-schema-editor";
+import discourseComputed from "discourse-common/utils/decorators";
 import ThemeSettingEditor from "admin/components/theme-setting-editor";
 
 export default class UserThemeSettingEditor extends ThemeSettingEditor {
-  @url("model.id", "/user_themes/%@/setting") updateUrl;
+  @discourseComputed("setting")
+  settingEditButton(setting) {
+    if (setting.json_schema) {
+      return {
+        action: () => {
+          this.modal.show(JsonSchemaEditorModal, {
+            model: {
+              updateValue: (value) => {
+                this.buffered.set("value", value);
+              },
+              value: this.buffered.get("value"),
+              settingName: setting.setting,
+              jsonSchema: setting.json_schema,
+            },
+          });
+        },
+        label: "admin.site_settings.json_schema.edit",
+        icon: "pencil-alt",
+      };
+    } else if (setting.objects_schema) {
+      return {
+        action: () => {
+          this.router.transitionTo(
+            "user.themes.show.schema",
+            this.model.id,
+            setting.setting
+          );
+        },
+        label: "admin.customize.theme.edit_objects_theme_setting",
+        icon: "pencil-alt",
+      };
+    }
+  }
 }

--- a/assets/javascripts/discourse/models/user-theme-settings.js
+++ b/assets/javascripts/discourse/models/user-theme-settings.js
@@ -1,0 +1,13 @@
+import { ajax } from "discourse/lib/ajax";
+import { popupAjaxError } from "discourse/lib/ajax-error";
+import ThemeSettings from "admin/models/theme-settings";
+
+export default class UserThemeSettings extends ThemeSettings {
+  loadMetadata(themeId) {
+    return ajax(
+      `/user_themes/${themeId}/objects_setting_metadata/${this.setting}.json`
+    )
+      .then((result) => this.set("metadata", result))
+      .catch(popupAjaxError);
+  }
+}

--- a/assets/javascripts/discourse/models/user-theme.js
+++ b/assets/javascripts/discourse/models/user-theme.js
@@ -1,3 +1,14 @@
 import Theme from "admin/models/theme";
+import UserThemeSettings from "./user-theme-settings";
 
-export default class UserTheme extends Theme {}
+export default class UserTheme extends Theme {
+  static munge(json) {
+    if (json.settings) {
+      json.settings = json.settings.map((setting) =>
+        UserThemeSettings.create(setting)
+      );
+    }
+
+    return json;
+  }
+}

--- a/assets/javascripts/discourse/routes/user-themes-show-schema.js
+++ b/assets/javascripts/discourse/routes/user-themes-show-schema.js
@@ -1,0 +1,19 @@
+import { inject as service } from "@ember/service";
+import DiscourseRoute from "discourse/routes/discourse";
+
+export default class UserThemesShowSchema extends DiscourseRoute {
+  @service router;
+
+  async model(params) {
+    const all = this.modelFor("user.themes");
+    const theme = all.findBy("id", parseInt(params.theme_id, 10));
+    const setting = theme.settings.findBy("setting", params.setting_name);
+
+    await setting.loadMetadata(theme.id);
+
+    return {
+      theme,
+      setting,
+    };
+  }
+}

--- a/assets/javascripts/discourse/templates/user-themes-show-schema.hbs
+++ b/assets/javascripts/discourse/templates/user-themes-show-schema.hbs
@@ -1,0 +1,20 @@
+<div class="customize-themes-show-schema__header row">
+  <LinkTo
+    @route="user.themes.show"
+    @model={{@model.theme.id}}
+    class="btn-transparent customize-themes-show-schema__back"
+  >
+    {{d-icon "arrow-left"}}{{@model.theme.name}}
+  </LinkTo>
+  <h2>
+    {{i18n
+      "admin.customize.theme.schema.title"
+      (hash name=@model.setting.setting)
+    }}
+  </h2>
+</div>
+
+<UserSchemaThemeSetting::Editor
+  @themeId={{@model.theme.id}}
+  @setting={{@model.setting}}
+/>

--- a/assets/javascripts/discourse/theme-creator-user-route-map.js
+++ b/assets/javascripts/discourse/theme-creator-user-route-map.js
@@ -4,6 +4,7 @@ export default {
   map() {
     this.route("themes", function () {
       this.route("show", { path: "/:theme_id" });
+      this.route("show.schema", { path: "/:theme_id/schema/:setting_name" });
       this.route("edit", { path: "/:theme_id/:target/:field_name/edit" });
       this.route("colors", { path: "/:theme_id/colors/:color_scheme_id" });
     });

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,10 @@ Discourse::Application.routes.draw do
       }
   get "u/:username/themes" => "users#index", :constraints => { username: RouteFormat.username }
   get "u/:username/themes/:id" => "users#index", :constraints => { username: RouteFormat.username }
+  get "u/:username/themes/:id/schema/:setting_name" => "users#index",
+      :constraints => {
+        username: RouteFormat.username,
+      }
   get "u/:username/themes/:theme_id/colors/:color_scheme_id" => "users#index",
       :constraints => {
         username: RouteFormat.username,
@@ -45,4 +49,7 @@ ThemeCreator::Engine.routes.draw do
   post ":id/colors" => "theme_creator#create_color_scheme"
   put ":id/colors/:color_scheme_id" => "theme_creator#update_color_scheme"
   delete ":id/colors/:color_scheme_id" => "theme_creator#destroy_color_scheme"
+
+  # objects_setting_metadata
+  get ":id/objects_setting_metadata/:setting_name" => "theme_creator#objects_setting_metadata"
 end

--- a/spec/system/user_theme_object_setting_spec.rb
+++ b/spec/system/user_theme_object_setting_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+RSpec.describe "Discourse Theme Creator - user theme object setting", system: true do
+  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:theme) { Fabricate(:theme, name: "Cool theme 1", component: true, user: current_user) }
+
+  let(:objects_setting) do
+    theme.set_field(
+      target: :settings,
+      name: "yaml",
+      value: File.read("#{Rails.root}/spec/fixtures/theme_settings/objects_settings.yaml"),
+    )
+
+    theme.save!
+    theme.settings[:objects_setting]
+  end
+
+  let(:admin_customize_themes_page) { PageObjects::Pages::AdminCustomizeThemes.new }
+
+  let(:admin_objects_theme_setting_editor_page) do
+    PageObjects::Pages::AdminObjectsThemeSettingEditor.new
+  end
+
+  before do
+    objects_setting
+    sign_in(current_user)
+  end
+
+  it "can edit object settings" do
+    visit "/u/#{current_user.username}/themes/#{theme.id}"
+
+    admin_customize_themes_page.click_edit_objects_theme_setting_button("objects_setting")
+    admin_objects_theme_setting_editor_page.fill_in_field("name", "test")
+    admin_objects_theme_setting_editor_page.save
+
+    expect(admin_objects_theme_setting_editor_page).to have_setting_field("name", "test")
+  end
+end

--- a/spec/system/user_theme_setting_spec.rb
+++ b/spec/system/user_theme_setting_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+RSpec.describe "Discourse Theme Creator - user theme setting", system: true do
+  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:theme) { Fabricate(:theme, component: true, user: current_user) }
+
+  before do
+    theme.set_field(target: :settings, name: "yaml", value: <<~YAML)
+        super_feature_enabled:
+          type: bool
+          default: false
+          refresh: false
+      YAML
+
+    ThemeSetting.create!(
+      theme: theme,
+      data_type: ThemeSetting.types[:bool],
+      name: "super_feature_enabled",
+    )
+    theme.save!
+  end
+
+  let(:admin_customize_themes_page) { PageObjects::Pages::AdminCustomizeThemes.new }
+
+  before { sign_in(current_user) }
+
+  it "can edit settings" do
+    visit "/u/#{current_user.username}/themes/#{theme.id}"
+
+    find("[data-setting='super_feature_enabled'] .setting-value").click
+    find(".setting-controls__ok").click
+
+    expect(admin_customize_themes_page).to have_overridden_setting("super_feature_enabled")
+  end
+end

--- a/spec/theme_creator_controller_spec.rb
+++ b/spec/theme_creator_controller_spec.rb
@@ -85,6 +85,29 @@ RSpec.describe "Theme Creator Controller", type: :request do
     end
   end
 
+  describe "objects_setting_metadata" do
+    before do
+      theme.set_field(
+        target: :settings,
+        name: "yaml",
+        value: File.read("#{Rails.root}/spec/fixtures/theme_settings/objects_settings.yaml"),
+      )
+
+      theme.save!
+    end
+
+    it "fails to fetch metadata of other users themes" do
+      get "/user_themes/#{theme.id}/objects_setting_metadata/objects_setting.json"
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "fetches metadata of own themes" do
+      sign_in(user1)
+      get "/user_themes/#{theme.id}/objects_setting_metadata/objects_setting.json"
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
   describe "show" do
     it "fails to download other users themes" do
       get "/user_themes/#{theme.id}/export"


### PR DESCRIPTION
Prior to this fix, editing settings was broken as it was not in line with latest core changes related to object settings.

This commit had the missing bits:
- user accessible objects_setting_metadata endpoint (it was restricted to admins)
- override the various new components/models to handle user themes path instead of admin themes path

This commit also adds specs.