### PR TITLE
FIX: ensures user can save theme setting

### DIFF
--- a/assets/javascripts/discourse/models/user-theme-settings.js
+++ b/assets/javascripts/discourse/models/user-theme-settings.js
@@ -10,4 +10,18 @@ export default class UserThemeSettings extends ThemeSettings {
       .then((result) => this.set("metadata", result))
       .catch(popupAjaxError);
   }
+
+  updateSetting(themeId, newValue) {
+    if (this.objects_schema) {
+      newValue = JSON.stringify(newValue);
+    }
+
+    return ajax(`/user_themes/${themeId}/setting`, {
+      type: "PUT",
+      data: {
+        name: this.setting,
+        value: newValue,
+      },
+    });
+  }
 }

--- a/spec/system/user_theme_setting_spec.rb
+++ b/spec/system/user_theme_setting_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "Discourse Theme Creator - user theme setting", system: true do
-  fab!(:current_user) { Fabricate(:admin) }
+  fab!(:current_user) { Fabricate(:user) }
   fab!(:theme) { Fabricate(:theme, component: true, user: current_user) }
 
   before do


### PR DESCRIPTION
The previous test was wrong as using an admin user to test it, moreover it was missing a change in user-theme-settings to ensure that click save from the user themes is correctly calling the user_themes endpoint and not trying to reach for admin endpoints.