### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20201028134841_update_user_api_key_scopes.rb
+++ b/db/migrate/20201028134841_update_user_api_key_scopes.rb
@@ -8,4 +8,8 @@ class UpdateUserApiKeyScopes < ActiveRecord::Migration[6.0]
       WHERE name = 'user_themes'
     SQL
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.