### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/modal/user-themes-share-modal.hbs
+++ b/assets/javascripts/discourse/components/modal/user-themes-share-modal.hbs
@@ -22,7 +22,7 @@
         <DButton
           @action={{action "cancelEditingSlug"}}
           class="btn-small cancel-edit"
-          @icon="times"
+          @icon="xmark"
         />
 
         <p>{{i18n "theme_creator.share_destination"}}</p>
@@ -41,7 +41,7 @@
         <DButton
           @action={{action "cancelEditingSlug"}}
           class="btn-small cancel-edit"
-          @icon="times"
+          @icon="xmark"
         />
       {{else}}
         <code>
@@ -61,7 +61,7 @@
       <p>
         <DButton
           @action={{action "stopSharing"}}
-          @icon="times-circle"
+          @icon="circle-xmark"
           class="btn-danger btn-large"
           @label="theme_creator.stop_sharing"
         />

--- a/assets/javascripts/discourse/components/user-theme-setting-editor.js
+++ b/assets/javascripts/discourse/components/user-theme-setting-editor.js
@@ -20,7 +20,7 @@ export default class UserThemeSettingEditor extends ThemeSettingEditor {
           });
         },
         label: "admin.site_settings.json_schema.edit",
-        icon: "pencil-alt",
+        icon: "pencil",
       };
     } else if (setting.objects_schema) {
       return {
@@ -32,7 +32,7 @@ export default class UserThemeSettingEditor extends ThemeSettingEditor {
           );
         },
         label: "admin.customize.theme.edit_objects_theme_setting",
-        icon: "pencil-alt",
+        icon: "pencil",
       };
     }
   }

--- a/assets/javascripts/discourse/templates/components/theme-metadata-field.hbs
+++ b/assets/javascripts/discourse/templates/components/theme-metadata-field.hbs
@@ -10,7 +10,7 @@
   <DButton
     @action={{action "cancelEditing"}}
     class="btn-small cancel-edit"
-    @icon="times"
+    @icon="xmark"
   />
 {{else}}
   {{#if this.value}}

--- a/assets/javascripts/discourse/templates/user-themes-show.hbs
+++ b/assets/javascripts/discourse/templates/user-themes-show.hbs
@@ -10,7 +10,7 @@
       />
       <DButton
         @action={{action "cancelEditingName"}}
-        @icon="times"
+        @icon="xmark"
         class="btn-small cancel-edit"
       />
     {{else}}
@@ -140,7 +140,7 @@
         {{else}}
           <DButton
             @action={{action "checkForThemeUpdates"}}
-            @icon="sync"
+            @icon="arrows-rotate"
             @label="admin.customize.theme.check_for_updates"
             class="btn-default"
           />
@@ -239,7 +239,7 @@
         @save={{action "saveMetadata"}}
       />
       <ThemeMetadataField
-        @icon="info-circle"
+        @icon="circle-info"
         @label="theme_creator.theme_version"
         @value={{this.model.remote_theme.theme_version}}
         @save={{action "saveMetadata"}}
@@ -272,7 +272,7 @@
           <ComboBox
             @content={{this.colorSchemes}}
             @value={{this.colorSchemeId}}
-            @icon="paint-brush"
+            @icon="paintbrush"
             @options={{hash filterable=true}}
           />
           {{#if this.colorSchemeChanged}}
@@ -283,7 +283,7 @@
             />
             <DButton
               @action={{action "cancelChangeScheme"}}
-              @icon="times"
+              @icon="xmark"
               class="btn-default cancel-edit"
             />
           {{else}}
@@ -299,7 +299,7 @@
             <DButton
               @action={{action "destroyColorScheme"}}
               @title="theme_creator.delete_color_scheme"
-              @icon="trash-alt"
+              @icon="trash-can"
               @disabled={{this.colorSchemeEditDisabled}}
               class="btn-danger"
             />
@@ -372,7 +372,7 @@
               <span class="col">
                 <DButton
                   @action={{action "removeUpload" upload}}
-                  @icon="times"
+                  @icon="xmark"
                   class="second btn-default cancel-edit"
                 />
               </span>
@@ -446,7 +446,7 @@
         />
         <DButton
           @action={{action "showAdvancedAction"}}
-          @icon="cog"
+          @icon="gear"
           @label="theme_creator.show_advanced"
         />
       </div>
@@ -473,13 +473,13 @@
     {{#if this.quickColorScheme}}
       <DButton
         @action={{action "showAdvancedAction"}}
-        @icon="cog"
+        @icon="gear"
         @label="theme_creator.show_advanced"
       />
     {{else if this.showAdvanced}}
       <DButton
         @action={{route-action "editLocalModal"}}
-        @icon="pencil-alt"
+        @icon="pencil"
         @label="theme_creator.edit_local"
       />
     {{/if}}
@@ -512,7 +512,7 @@
     <DButton
       @action={{action "destroy"}}
       @label="theme_creator.delete"
-      @icon="trash-alt"
+      @icon="trash-can"
       class="btn-danger"
     />
   </div>


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.