### PR TITLE
FIX: use new user api client key system in discourse/discourse

### DIFF
--- a/app/controllers/theme_creator/theme_creator_controller.rb
+++ b/app/controllers/theme_creator/theme_creator_controller.rb
@@ -26,13 +26,14 @@ class ThemeCreator::ThemeCreatorController < Admin::ThemesController
   skip_before_action :check_xhr, only: %i[share_info preview share_preview]
 
   def fetch_api_key
-    client_id = "theme_cli_#{current_user.id}"
-
-    UserApiKey.where(user_id: current_user.id, client_id: client_id).destroy_all
-    api_key =
-      UserApiKey.create!(
+    client =
+      UserApiKeyClient.find_or_create_by(
+        client_id: "theme_cli_#{current_user.id}",
         application_name: I18n.t("theme_creator.api_application_name"),
-        client_id: client_id,
+      )
+
+    api_key =
+      client.keys.create!(
         user_id: current_user.id,
         scopes: [UserApiKeyScope.new(name: "discourse-theme-creator:user_themes")],
       )

--- a/spec/theme_creator_controller_spec.rb
+++ b/spec/theme_creator_controller_spec.rb
@@ -235,4 +235,20 @@ RSpec.describe "Theme Creator Controller", type: :request do
       end
     end
   end
+
+  describe "fetch_api_key" do
+    before { sign_in(user1) }
+
+    it "creates a client and a key" do
+      post "/user_themes/fetch_api_key.json"
+      expect(response).to be_successful
+      client = UserApiKeyClient.find_by(client_id: "theme_cli_#{user1.id}")
+      expect(response.parsed_body["api_key"]).to be_present
+    end
+
+    it "only creates one client" do
+      Fabricate(:user_api_key_client, client_id: "theme_cli_#{user1.id}")
+      expect { post "/user_themes/fetch_api_key.json" }.not_to change { UserApiKeyClient.count }
+    end
+  end
 end

--- a/spec/theme_creator_controller_spec.rb
+++ b/spec/theme_creator_controller_spec.rb
@@ -239,14 +239,13 @@ RSpec.describe "Theme Creator Controller", type: :request do
   describe "fetch_api_key" do
     before { sign_in(user1) }
 
-    it "creates a client and a key" do
+    it "returns a user api key" do
       post "/user_themes/fetch_api_key.json"
       expect(response).to be_successful
-      client = UserApiKeyClient.find_by(client_id: "theme_cli_#{user1.id}")
       expect(response.parsed_body["api_key"]).to be_present
     end
 
-    it "only creates one client" do
+    it "only creates one user api key client" do
       Fabricate(:user_api_key_client, client_id: "theme_cli_#{user1.id}")
       expect { post "/user_themes/fetch_api_key.json" }.not_to change { UserApiKeyClient.count }
     end


### PR DESCRIPTION
See https://meta.discourse.org/t/generate-api-key-in-theme-creator-failed/342247