### PR TITLE
DEV: Switch from legacy TextArea component to native input

### DIFF
--- a/assets/javascripts/discourse/components/modal/user-themes-share-modal.hbs
+++ b/assets/javascripts/discourse/components/modal/user-themes-share-modal.hbs
@@ -10,7 +10,12 @@
       {{#if this.editingSlug}}
         <code>
           {{@model.base_share_url}}
-          <TextField @value={{@model.share_slug}} @autofocus="true" />
+          <input
+            type="text"
+            value={{@model.share_slug}}
+            placeholder="/"
+            {{on "input" (with-event-value (fn (mut @model.share_slug)))}}
+          />
         </code>
 
         <DButton
@@ -29,7 +34,15 @@
 
         <code>
           {{@model.base_destination_url}}
-          <TextField @value={{@model.share_destination}} @autofocus="true" />
+          <input
+            type="text"
+            value={{@model.share_destination}}
+            placeholder="/"
+            {{on
+              "change"
+              (with-event-value (fn (mut @model.share_destination)))
+            }}
+          />
         </code>
 
         <DButton
@@ -71,14 +84,24 @@
 
       <code>
         {{@model.base_share_url}}
-        <TextField @value={{@model.share_slug}} @autofocus="true" />
+        <input
+          type="text"
+          value={{@model.share_slug}}
+          placeholder="/"
+          {{on "input" (with-event-value (fn (mut @model.share_slug)))}}
+        />
       </code>
 
       <p>{{i18n "theme_creator.share_destination_instructions"}}</p>
 
       <code>
         {{@model.base_destination_url}}
-        <TextField @value={{@model.share_destination}} @placeholder="/" />
+        <input
+          type="text"
+          value={{@model.share_destination}}
+          placeholder="/"
+          {{on "input" (with-event-value (fn (mut @model.share_destination)))}}
+        />
       </code>
 
       <p>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -21,12 +21,12 @@ en:
 
       show_advanced: "Advanced"
 
-      color_scheme: "Color Scheme"
-      color_scheme_belongs_to: "Color scheme for"
-      edit_color_scheme: "Edit Color Scheme"
-      delete_color_scheme: "Delete Color Scheme"
-      add_color_scheme: "Add Color Scheme"
-      adding_color_scheme: "Adding Color Scheme..."
+      color_scheme: "Color Palette"
+      color_scheme_belongs_to: "Color palette for"
+      edit_color_scheme: "Edit Color Palette"
+      delete_color_scheme: "Delete Color Palette"
+      add_color_scheme: "Add Color Palette"
+      adding_color_scheme: "Adding Color Palette..."
 
       css_html: "CSS/HTML"
       edit_css_html: "Edit CSS/HTML"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,7 +5,7 @@ en:
   site_settings:
     theme_creator_share_groups: "Names of groups that are allowed to share themes with other users. Leave blank to allow all users."
   theme_creator:
-    new_color_scheme: "New Color Scheme"
+    new_color_scheme: "New Color Palette"
     api_application_name: "Discourse Theme CLI"
     meta_title: "'%{theme_name}' by @%{username}"
     meta_description: "A theme for Discourse shared on theme-creator.discourse.org"


### PR DESCRIPTION
This should also resolve an 'attrs already updated' error we're seeing following a recent ember update