### PR TITLE
FIX: fix failing specs for user schema theme setting editor

### DIFF
--- a/assets/javascripts/discourse/components/user-schema-theme-setting-editor.gjs
+++ b/assets/javascripts/discourse/components/user-schema-theme-setting-editor.gjs
@@ -1,6 +1,6 @@
 import { action } from "@ember/object";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import SchemaThemeSettingEditor from "admin/components/schema-theme-setting/editor";
+import SchemaThemeSettingEditor from "admin/components/schema-setting/editor";
 
 export default class UserSchemaThemeSettingEditor extends SchemaThemeSettingEditor {
   @action
@@ -8,11 +8,11 @@ export default class UserSchemaThemeSettingEditor extends SchemaThemeSettingEdit
     this.saveButtonDisabled = true;
 
     this.args.setting
-      .updateSetting(this.args.themeId, this.data)
+      .updateSetting(this.args.id, this.data)
       .then((result) => {
         this.args.setting.set("value", result[this.args.setting.setting]);
 
-        this.router.transitionTo("user.themes.show", this.args.themeId);
+        this.router.transitionTo("user.themes.show", this.args.id);
       })
       .catch((e) => {
         if (e.jqXHR.responseJSON && e.jqXHR.responseJSON.errors) {

--- a/assets/javascripts/discourse/templates/user-themes-show-schema.hbs
+++ b/assets/javascripts/discourse/templates/user-themes-show-schema.hbs
@@ -15,6 +15,8 @@
 </div>
 
 <UserSchemaThemeSetting::Editor
-  @themeId={{@model.theme.id}}
+  @id={{@model.theme.id}}
+  @routeToRedirect="user.themes.show"
+  @schema={{@model.setting.objects_schema}}
   @setting={{@model.setting}}
 />


### PR DESCRIPTION
Due to the changes in https://github.com/discourse/discourse/commit/4d99c839b6032808c153df1aed752d1a470cb190#diff-276ade29bcc14f26395018ebf94fa8c98b57f161ed6054b5060ad557b13d0e7f

we needed to update imports in the component and update variable naming. Changed how props were passed to the component to match the new structure on the `.hbs` file.