### PR TITLE
FIX: Edit code button

### DIFF
--- a/assets/javascripts/discourse/adapters/user-theme.js
+++ b/assets/javascripts/discourse/adapters/user-theme.js
@@ -1,6 +1,6 @@
 import { Result } from "discourse/adapters/rest";
+import ThemeAdapter from "discourse/admin/adapters/theme";
 import { ajax } from "discourse/lib/ajax";
-import ThemeAdapter from "admin/adapters/theme";
 
 export default class UserThemeAdapter extends ThemeAdapter {
   typeField = "theme";

--- a/assets/javascripts/discourse/components/color-scheme-editor.gjs
+++ b/assets/javascripts/discourse/components/color-scheme-editor.gjs
@@ -1,9 +1,9 @@
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 import { fn } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import ColorInput from "discourse/admin/components/color-input";
 import { i18n } from "discourse-i18n";
-import ColorInput from "admin/components/color-input";
 
 export default class ColorSchemeEditor extends Component {
   @action

--- a/assets/javascripts/discourse/components/user-schema-theme-setting-editor.gjs
+++ b/assets/javascripts/discourse/components/user-schema-theme-setting-editor.gjs
@@ -1,6 +1,6 @@
 import { action } from "@ember/object";
+import SchemaThemeSettingEditor from "discourse/admin/components/schema-setting/editor";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import SchemaThemeSettingEditor from "admin/components/schema-setting/editor";
 
 export default class UserSchemaThemeSettingEditor extends SchemaThemeSettingEditor {
   @action

--- a/assets/javascripts/discourse/components/user-theme-setting-editor.js
+++ b/assets/javascripts/discourse/components/user-theme-setting-editor.js
@@ -1,5 +1,5 @@
+import ThemeSettingEditor from "discourse/admin/components/theme-setting-editor";
 import JsonSchemaEditorModal from "discourse/components/modal/json-schema-editor";
-import ThemeSettingEditor from "admin/components/theme-setting-editor";
 
 export default class UserThemeSettingEditor extends ThemeSettingEditor {
   get settingEditButton() {

--- a/assets/javascripts/discourse/components/user-theme-translation.js
+++ b/assets/javascripts/discourse/components/user-theme-translation.js
@@ -1,5 +1,5 @@
+import ThemeTranslation from "discourse/admin/components/theme-translation";
 import { url } from "discourse/lib/computed";
-import ThemeTranslation from "admin/components/theme-translation";
 
 export default class UserThemeTranslation extends ThemeTranslation {
   @url("model.id", "/user_themes/%@") updateUrl;

--- a/assets/javascripts/discourse/components/user-themes-view.gjs
+++ b/assets/javascripts/discourse/components/user-themes-view.gjs
@@ -3,11 +3,11 @@ import { Input } from "@ember/component";
 import { action } from "@ember/object";
 import { next } from "@ember/runloop";
 import { service } from "@ember/service";
-import { or } from "truth-helpers";
 import DButton from "discourse/components/d-button";
 import avatar from "discourse/helpers/avatar";
 import { ajax } from "discourse/lib/ajax";
 import getURL from "discourse/lib/get-url";
+import { or } from "discourse/truth-helpers";
 import { i18n } from "discourse-i18n";
 
 export default class UserThemesViewModal extends Component {

--- a/assets/javascripts/discourse/controllers/user/themes/edit.js
+++ b/assets/javascripts/discourse/controllers/user/themes/edit.js
@@ -1,5 +1,5 @@
+import AdminCustomizeThemesEdit from "discourse/admin/controllers/admin-customize-themes/edit";
 import { url } from "discourse/lib/computed";
-import AdminCustomizeThemesEdit from "admin/controllers/admin-customize-themes-edit";
 
 export default class UserThemesEdit extends AdminCustomizeThemesEdit {
   @url("model.id", "/user_themes/%@/preview") previewUrl;

--- a/assets/javascripts/discourse/controllers/user/themes/show.js
+++ b/assets/javascripts/discourse/controllers/user/themes/show.js
@@ -1,13 +1,13 @@
 import EmberObject, { action } from "@ember/object";
 import { alias } from "@ember/object/computed";
 import { service } from "@ember/service";
+import ThemeUploadAddModal from "discourse/admin/components/theme-upload-add";
+import AdminCustomizeThemesShowIndexController from "discourse/admin/controllers/admin-customize-themes/show/index";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import { url } from "discourse/lib/computed";
 import discourseComputed from "discourse/lib/decorators";
 import { i18n } from "discourse-i18n";
-import ThemeUploadAddModal from "admin/components/theme-upload-add";
-import AdminCustomizeThemesShowIndexController from "admin/controllers/admin-customize-themes/show/index";
 import UserThemesShareModal from "../../../components/modal/user-themes-share-modal";
 
 export default class UserThemesShow extends AdminCustomizeThemesShowIndexController {

--- a/assets/javascripts/discourse/models/user-color-scheme.js
+++ b/assets/javascripts/discourse/models/user-color-scheme.js
@@ -1,5 +1,5 @@
+import ColorScheme from "discourse/admin/models/color-scheme";
 import { ajax } from "discourse/lib/ajax";
-import ColorScheme from "admin/models/color-scheme";
 
 export default class UserColorScheme extends ColorScheme {
   save() {

--- a/assets/javascripts/discourse/models/user-theme-settings.js
+++ b/assets/javascripts/discourse/models/user-theme-settings.js
@@ -1,6 +1,6 @@
+import ThemeSettings from "discourse/admin/models/theme-settings";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
-import ThemeSettings from "admin/models/theme-settings";
 
 export default class UserThemeSettings extends ThemeSettings {
   loadMetadata(themeId) {

--- a/assets/javascripts/discourse/models/user-theme.js
+++ b/assets/javascripts/discourse/models/user-theme.js
@@ -1,4 +1,4 @@
-import Theme from "admin/models/theme";
+import Theme from "discourse/admin/models/theme";
 import UserThemeSettings from "./user-theme-settings";
 
 export default class UserTheme extends Theme {

--- a/assets/javascripts/discourse/routes/user/themes.js
+++ b/assets/javascripts/discourse/routes/user/themes.js
@@ -3,10 +3,10 @@
 import ArrayProxy from "@ember/array/proxy";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
+import InstallThemeModal from "discourse/admin/components/modal/install-theme";
+import ColorSchemeColor from "discourse/admin/models/color-scheme-color";
 import DiscourseRoute from "discourse/routes/discourse";
 import { i18n } from "discourse-i18n";
-import InstallThemeModal from "admin/components/modal/install-theme";
-import ColorSchemeColor from "admin/models/color-scheme-color";
 import UserThemesEditLocalModal from "../../components/modal/user-themes-edit-local-modal";
 import UserColorScheme from "../../models/user-color-scheme";
 

--- a/assets/javascripts/discourse/routes/user/themes/edit.js
+++ b/assets/javascripts/discourse/routes/user/themes/edit.js
@@ -7,7 +7,7 @@ export default class extends DiscourseRoute {
   @service dialog;
   @service router;
 
-  templateName = "adminCustomizeThemesEdit";
+  templateName = "admin-customize-themes/edit";
 
   model(params) {
     const all = this.modelFor("user.themes");

--- a/assets/javascripts/discourse/routes/user/themes/index.js
+++ b/assets/javascripts/discourse/routes/user/themes/index.js
@@ -1,4 +1,4 @@
-import AdminCustomizeThemesIndex from "admin/routes/admin-customize-themes/index";
+import AdminCustomizeThemesIndex from "discourse/admin/routes/admin-customize-themes/index";
 
 export default class UserThemesIndex extends AdminCustomizeThemesIndex {
   templateName = "adminCustomizeThemesIndex";

--- a/assets/javascripts/discourse/templates/theme-share.gjs
+++ b/assets/javascripts/discourse/templates/theme-share.gjs
@@ -1,6 +1,3 @@
-import RouteTemplate from "ember-route-template";
 import UserThemesView from "../components/user-themes-view";
 
-export default RouteTemplate(
-  <template><UserThemesView @model={{@model}} /></template>
-);
+export default <template><UserThemesView @model={{@model}} /></template>

--- a/assets/javascripts/discourse/templates/user/themes.gjs
+++ b/assets/javascripts/discourse/templates/user/themes.gjs
@@ -1,53 +1,50 @@
 import { LinkTo } from "@ember/routing";
-import RouteTemplate from "ember-route-template";
 import DButton from "discourse/components/d-button";
 import routeAction from "discourse/helpers/route-action";
 import { i18n } from "discourse-i18n";
 
-export default RouteTemplate(
-  <template>
-    <div class="user-theme-creator">
-      {{#unless @controller.editingTheme}}
-        <div class="user-theme-list">
-          <LinkTo @route="user.themes">
-            <div class="user-theme-list-heading">
-              {{i18n "theme_creator.my_themes"}}
-            </div>
-          </LinkTo>
-
-          <ul>
-            {{#each @controller.model as |theme|}}
-              <li>
-                <LinkTo
-                  @route="user.themes.show"
-                  @model={{theme}}
-                  @replace={{true}}
-                >
-                  {{theme.name}}
-                </LinkTo>
-              </li>
-            {{/each}}
-          </ul>
-
-          <div class="user-create-theme">
-            <DButton
-              @action={{routeAction "installModal"}}
-              @icon="upload"
-              @label="theme_creator.install_theme"
-              class="btn-primary"
-            />
-            <DButton
-              @action={{routeAction "editLocalModal"}}
-              @icon="laptop-code"
-              @label="theme_creator.api_key"
-            />
+export default <template>
+  <div class="user-theme-creator">
+    {{#unless @controller.editingTheme}}
+      <div class="user-theme-list">
+        <LinkTo @route="user.themes">
+          <div class="user-theme-list-heading">
+            {{i18n "theme_creator.my_themes"}}
           </div>
-        </div>
-      {{/unless}}
+        </LinkTo>
 
-      <div class="user-theme-details {{if @controller.editingTheme 'editing'}}">
-        {{outlet}}
+        <ul>
+          {{#each @controller.model as |theme|}}
+            <li>
+              <LinkTo
+                @route="user.themes.show"
+                @model={{theme}}
+                @replace={{true}}
+              >
+                {{theme.name}}
+              </LinkTo>
+            </li>
+          {{/each}}
+        </ul>
+
+        <div class="user-create-theme">
+          <DButton
+            @action={{routeAction "installModal"}}
+            @icon="upload"
+            @label="theme_creator.install_theme"
+            class="btn-primary"
+          />
+          <DButton
+            @action={{routeAction "editLocalModal"}}
+            @icon="laptop-code"
+            @label="theme_creator.api_key"
+          />
+        </div>
       </div>
+    {{/unless}}
+
+    <div class="user-theme-details {{if @controller.editingTheme 'editing'}}">
+      {{outlet}}
     </div>
-  </template>
-);
+  </div>
+</template>

--- a/assets/javascripts/discourse/templates/user/themes/colors.gjs
+++ b/assets/javascripts/discourse/templates/user/themes/colors.gjs
@@ -1,51 +1,48 @@
 import { LinkTo } from "@ember/routing";
-import RouteTemplate from "ember-route-template";
 import DButton from "discourse/components/d-button";
 import TextField from "discourse/components/text-field";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import ColorSchemeEditor from "../../../components/color-scheme-editor";
 
-export default RouteTemplate(
-  <template>
-    <div class="theme-content">
-      <h2>
-        <TextField @value={{@controller.model.name}} @autofocus="true" />
-      </h2>
+export default <template>
+  <div class="theme-content">
+    <h2>
+      <TextField @value={{@controller.model.name}} @autofocus="true" />
+    </h2>
 
-      <h4>
-        ({{i18n "theme_creator.color_scheme_belongs_to"}}
-        <LinkTo
-          @route="user.themes.show"
-          @model={{@controller.model.theme_id}}
-          @replace={{true}}
-        >
-          {{@controller.model.theme_name}}
-        </LinkTo>)
-      </h4>
-
-      <ColorSchemeEditor @colors={{@controller.model.colors}} />
-
-      <DButton
-        @action={{@controller.save}}
-        @disabled={{@controller.isSaving}}
-        class="btn-primary"
+    <h4>
+      ({{i18n "theme_creator.color_scheme_belongs_to"}}
+      <LinkTo
+        @route="user.themes.show"
+        @model={{@controller.model.theme_id}}
+        @replace={{true}}
       >
-        {{@controller.saveButtonText}}
-      </DButton>
+        {{@controller.model.theme_name}}
+      </LinkTo>)
+    </h4>
 
-      {{#unless @controller.hidePreview}}
-        <a
-          href={{@controller.previewUrl}}
-          title={{i18n "theme_creator.explain_preview"}}
-          class="btn"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {{icon "desktop"}}
-          {{i18n "theme_creator.preview"}}
-        </a>
-      {{/unless}}
-    </div>
-  </template>
-);
+    <ColorSchemeEditor @colors={{@controller.model.colors}} />
+
+    <DButton
+      @action={{@controller.save}}
+      @disabled={{@controller.isSaving}}
+      class="btn-primary"
+    >
+      {{@controller.saveButtonText}}
+    </DButton>
+
+    {{#unless @controller.hidePreview}}
+      <a
+        href={{@controller.previewUrl}}
+        title={{i18n "theme_creator.explain_preview"}}
+        class="btn"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {{icon "desktop"}}
+        {{i18n "theme_creator.preview"}}
+      </a>
+    {{/unless}}
+  </div>
+</template>

--- a/assets/javascripts/discourse/templates/user/themes/show.gjs
+++ b/assets/javascripts/discourse/templates/user/themes/show.gjs
@@ -1,555 +1,552 @@
 import { array, concat, fn, hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { LinkTo } from "@ember/routing";
-import RouteTemplate from "ember-route-template";
 import DButton from "discourse/components/d-button";
 import TextField from "discourse/components/text-field";
 import icon from "discourse/helpers/d-icon";
 import formatDate from "discourse/helpers/format-date";
 import routeAction from "discourse/helpers/route-action";
+import ComboBox from "discourse/select-kit/components/combo-box";
 import { i18n } from "discourse-i18n";
-import ComboBox from "select-kit/components/combo-box";
 import ColorSchemeEditor from "../../../components/color-scheme-editor";
 import ThemeMetadataField from "../../../components/theme-metadata-field";
 import UserThemeSettingEditor from "../../../components/user-theme-setting-editor";
 import UserThemeTranslation from "../../../components/user-theme-translation";
 
-export default RouteTemplate(
-  <template>
-    <div class="show-current-style">
-      <h1>
-        {{#if @controller.editingName}}
-          <TextField @value={{@controller.model.name}} @autofocus="true" />
+export default <template>
+  <div class="show-current-style">
+    <h1>
+      {{#if @controller.editingName}}
+        <TextField @value={{@controller.model.name}} @autofocus="true" />
 
-          <DButton
-            @action={{@controller.finishedEditingName}}
-            @icon="check"
-            class="btn-primary btn-small submit-edit"
-          />
-          <DButton
-            @action={{@controller.cancelEditingName}}
-            @icon="xmark"
-            class="btn-small cancel-edit"
-          />
-        {{else}}
-          <span>{{@controller.model.name}}</span>
-          <DButton
-            @action={{@controller.startEditingName}}
-            @icon="pencil"
-            class="btn-small"
-          />
-        {{/if}}
-      </h1>
+        <DButton
+          @action={{@controller.finishedEditingName}}
+          @icon="check"
+          class="btn-primary btn-small submit-edit"
+        />
+        <DButton
+          @action={{@controller.cancelEditingName}}
+          @icon="xmark"
+          class="btn-small cancel-edit"
+        />
+      {{else}}
+        <span>{{@controller.model.name}}</span>
+        <DButton
+          @action={{@controller.startEditingName}}
+          @icon="pencil"
+          class="btn-small"
+        />
+      {{/if}}
+    </h1>
 
-      {{#if @controller.model.is_shared}}
-        {{#if @controller.model.can_share}}
-          <div class="control-unit share-information">
-            {{i18n "theme_creator.shared_at"}}
+    {{#if @controller.model.is_shared}}
+      {{#if @controller.model.can_share}}
+        <div class="control-unit share-information">
+          {{i18n "theme_creator.shared_at"}}
 
-            <code>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href={{concat
-                  @controller.model.base_share_url
-                  @controller.model.share_slug
-                }}
-              >
-                {{@controller.model.base_share_url}}{{@controller.model.share_slug}}
-              </a>
-            </code>
-
-            <a href {{on "click" @controller.shareModal}}>
-              {{icon "pencil"}}
+          <code>
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={{concat
+                @controller.model.base_share_url
+                @controller.model.share_slug
+              }}
+            >
+              {{@controller.model.base_share_url}}{{@controller.model.share_slug}}
             </a>
-          </div>
+          </code>
+
+          <a href {{on "click" @controller.shareModal}}>
+            {{icon "pencil"}}
+          </a>
+        </div>
+      {{/if}}
+    {{/if}}
+
+    {{#each @controller.model.errors as |error|}}
+      <div class="alert alert-error">
+        <button type="button" class="close" data-dismiss="alert">
+          ×
+        </button>
+        {{error}}
+      </div>
+    {{/each}}
+
+    {{#unless @controller.model.enabled}}
+      <div class="alert alert-error">
+        {{i18n "admin.customize.theme.required_version.error"}}
+        {{#if @controller.model.remote_theme.minimum_discourse_version}}
+          {{i18n
+            "admin.customize.theme.required_version.minimum"
+            version=@controller.model.remote_theme.minimum_discourse_version
+          }}
         {{/if}}
+        {{#if @controller.model.remote_theme.maximum_discourse_version}}
+          {{i18n
+            "admin.customize.theme.required_version.maximum"
+            version=@controller.model.remote_theme.maximum_discourse_version
+          }}
+        {{/if}}
+      </div>
+    {{/unless}}
+
+    {{#if @controller.model.remote_theme}}
+      {{#if @controller.model.remote_theme.remote_url}}
+        <a
+          class="remote-url"
+          href={{@controller.model.remote_theme.remote_url}}
+        >
+          {{i18n "admin.customize.theme.source_url"}}
+          {{icon "link"}}
+        </a>
+      {{/if}}
+      {{#if @controller.model.remote_theme.about_url}}
+        <a
+          class="url about-url"
+          href={{@controller.model.remote_theme.about_url}}
+        >
+          {{i18n "admin.customize.theme.about_theme"}}
+          {{icon "link"}}
+        </a>
+      {{/if}}
+      {{#if @controller.model.remote_theme.license_url}}
+        <a
+          class="url license-url"
+          href={{@controller.model.remote_theme.license_url}}
+        >
+          {{i18n "admin.customize.theme.license"}}
+          {{icon "link"}}
+        </a>
       {{/if}}
 
-      {{#each @controller.model.errors as |error|}}
-        <div class="alert alert-error">
-          <button type="button" class="close" data-dismiss="alert">
-            ×
-          </button>
-          {{error}}
-        </div>
-      {{/each}}
+      {{#if @controller.model.description}}
+        <span class="theme-description">
+          {{@controller.model.description}}
+        </span>
+      {{/if}}
 
-      {{#unless @controller.model.enabled}}
-        <div class="alert alert-error">
-          {{i18n "admin.customize.theme.required_version.error"}}
-          {{#if @controller.model.remote_theme.minimum_discourse_version}}
-            {{i18n
-              "admin.customize.theme.required_version.minimum"
-              version=@controller.model.remote_theme.minimum_discourse_version
-            }}
-          {{/if}}
-          {{#if @controller.model.remote_theme.maximum_discourse_version}}
-            {{i18n
-              "admin.customize.theme.required_version.maximum"
-              version=@controller.model.remote_theme.maximum_discourse_version
-            }}
-          {{/if}}
-        </div>
-      {{/unless}}
-
-      {{#if @controller.model.remote_theme}}
-        {{#if @controller.model.remote_theme.remote_url}}
-          <a
-            class="remote-url"
-            href={{@controller.model.remote_theme.remote_url}}
-          >
-            {{i18n "admin.customize.theme.source_url"}}
-            {{icon "link"}}
-          </a>
-        {{/if}}
-        {{#if @controller.model.remote_theme.about_url}}
-          <a
-            class="url about-url"
-            href={{@controller.model.remote_theme.about_url}}
-          >
-            {{i18n "admin.customize.theme.about_theme"}}
-            {{icon "link"}}
-          </a>
-        {{/if}}
-        {{#if @controller.model.remote_theme.license_url}}
-          <a
-            class="url license-url"
-            href={{@controller.model.remote_theme.license_url}}
-          >
-            {{i18n "admin.customize.theme.license"}}
-            {{icon "link"}}
-          </a>
-        {{/if}}
-
-        {{#if @controller.model.description}}
-          <span class="theme-description">
-            {{@controller.model.description}}
+      <span class="metadata">
+        {{#if @controller.model.remote_theme.authors}}
+          <span class="authors">
+            <span class="heading">
+              {{i18n "admin.customize.theme.authors"}}
+            </span>
+            {{@controller.model.remote_theme.authors}}
           </span>
         {{/if}}
-
-        <span class="metadata">
-          {{#if @controller.model.remote_theme.authors}}
-            <span class="authors">
-              <span class="heading">
-                {{i18n "admin.customize.theme.authors"}}
-              </span>
-              {{@controller.model.remote_theme.authors}}
+        {{#if @controller.model.remote_theme.theme_version}}
+          <span class="version">
+            <span class="heading">
+              {{i18n "admin.customize.theme.version"}}
             </span>
-          {{/if}}
-          {{#if @controller.model.remote_theme.theme_version}}
-            <span class="version">
-              <span class="heading">
-                {{i18n "admin.customize.theme.version"}}
-              </span>
-              {{@controller.model.remote_theme.theme_version}}
-            </span>
-          {{/if}}
-        </span>
-
-        {{#if @controller.model.remote_theme.is_git}}
-          <div class="control-unit">
-            {{#if @controller.showRemoteError}}
-              <div class="error-message">
-                {{icon "triangle-exclamation"}}
-                {{i18n "admin.customize.theme.repo_unreachable"}}
-              </div>
-              <div class="raw-error">
-                <code>
-                  {{@controller.model.remoteError}}
-                </code>
-              </div>
-            {{/if}}
-
-            {{#if @controller.model.remote_theme.commits_behind}}
-              <DButton
-                @action={{@controller.updateToLatest}}
-                @icon="download"
-                @label="admin.customize.theme.update_to_latest"
-                class="btn-primary"
-              />
-            {{else}}
-              <DButton
-                @action={{@controller.checkForThemeUpdates}}
-                @icon="arrows-rotate"
-                @label="admin.customize.theme.check_for_updates"
-                class="btn-default"
-              />
-            {{/if}}
-
-            <span class="status-message">
-              {{#if @controller.updatingRemote}}
-                {{i18n "admin.customize.theme.updating"}}
-              {{else}}
-                {{#if @controller.model.remote_theme.commits_behind}}
-                  {{i18n
-                    "admin.customize.theme.commits_behind"
-                    count=@controller.model.remote_theme.commits_behind
-                  }}
-
-                  {{#if @controller.model.remote_theme.github_diff_link}}
-                    <a href={{@controller.model.remote_theme.github_diff_link}}>
-                      {{i18n "admin.customize.theme.compare_commits"}}
-                    </a>
-                  {{/if}}
-                {{else}}
-                  {{#unless @controller.showRemoteError}}
-                    {{i18n "admin.customize.theme.up_to_date"}}
-                    {{formatDate
-                      @controller.model.remote_theme.updated_at
-                      leaveAgo="true"
-                    }}
-                  {{/unless}}
-                {{/if}}
-              {{/if}}
-            </span>
-          </div>
+            {{@controller.model.remote_theme.theme_version}}
+          </span>
         {{/if}}
-      {{/if}}
+      </span>
 
-      {{#if @controller.showAdvanced}}
+      {{#if @controller.model.remote_theme.is_git}}
+        <div class="control-unit">
+          {{#if @controller.showRemoteError}}
+            <div class="error-message">
+              {{icon "triangle-exclamation"}}
+              {{i18n "admin.customize.theme.repo_unreachable"}}
+            </div>
+            <div class="raw-error">
+              <code>
+                {{@controller.model.remoteError}}
+              </code>
+            </div>
+          {{/if}}
+
+          {{#if @controller.model.remote_theme.commits_behind}}
+            <DButton
+              @action={{@controller.updateToLatest}}
+              @icon="download"
+              @label="admin.customize.theme.update_to_latest"
+              class="btn-primary"
+            />
+          {{else}}
+            <DButton
+              @action={{@controller.checkForThemeUpdates}}
+              @icon="arrows-rotate"
+              @label="admin.customize.theme.check_for_updates"
+              class="btn-default"
+            />
+          {{/if}}
+
+          <span class="status-message">
+            {{#if @controller.updatingRemote}}
+              {{i18n "admin.customize.theme.updating"}}
+            {{else}}
+              {{#if @controller.model.remote_theme.commits_behind}}
+                {{i18n
+                  "admin.customize.theme.commits_behind"
+                  count=@controller.model.remote_theme.commits_behind
+                }}
+
+                {{#if @controller.model.remote_theme.github_diff_link}}
+                  <a href={{@controller.model.remote_theme.github_diff_link}}>
+                    {{i18n "admin.customize.theme.compare_commits"}}
+                  </a>
+                {{/if}}
+              {{else}}
+                {{#unless @controller.showRemoteError}}
+                  {{i18n "admin.customize.theme.up_to_date"}}
+                  {{formatDate
+                    @controller.model.remote_theme.updated_at
+                    leaveAgo="true"
+                  }}
+                {{/unless}}
+              {{/if}}
+            {{/if}}
+          </span>
+        </div>
+      {{/if}}
+    {{/if}}
+
+    {{#if @controller.showAdvanced}}
+      <div class="control-unit">
+        <div class="mini-title">
+          {{#if @controller.model.component}}
+            {{i18n "theme_creator.component"}}
+          {{else}}
+            {{i18n "theme_creator.theme"}}
+          {{/if}}
+        </div>
+
+        <div class="description">
+          {{#if @controller.model.component}}
+            {{i18n "theme_creator.is_a_component"}}
+          {{else}}
+            {{i18n "theme_creator.is_a_theme"}}
+          {{/if}}
+        </div>
+
+        <div class="control">
+          {{#if @controller.model.component}}
+            <DButton
+              @action={{@controller.switchType}}
+              @label="theme_creator.convert_to_theme"
+              @icon={{@controller.convertIcon}}
+              @title={{@controller.convertTooltip}}
+              class="btn-default btn-normal"
+            />
+          {{else}}
+            <DButton
+              @action={{@controller.switchType}}
+              @label="theme_creator.convert_to_component"
+              @icon={{@controller.convertIcon}}
+              @title={{@controller.convertTooltip}}
+              class="btn-default btn-normal"
+            />
+          {{/if}}
+        </div>
+      </div>
+
+      <div class="control-unit metadata">
+        <div class="mini-title">
+          {{i18n "theme_creator.metadata"}}
+        </div>
+
+        <ThemeMetadataField
+          @icon="link"
+          @label="theme_creator.about_url"
+          @value={{@controller.model.remote_theme.about_url}}
+          @save={{@controller.saveMetadata}}
+        />
+        <ThemeMetadataField
+          @icon="link"
+          @label="theme_creator.license_url"
+          @value={{@controller.model.remote_theme.license_url}}
+          @save={{@controller.saveMetadata}}
+        />
+        <ThemeMetadataField
+          @icon="users"
+          @label="theme_creator.authors"
+          @value={{@controller.model.remote_theme.authors}}
+          @save={{@controller.saveMetadata}}
+        />
+        <ThemeMetadataField
+          @icon="circle-info"
+          @label="theme_creator.theme_version"
+          @value={{@controller.model.remote_theme.theme_version}}
+          @save={{@controller.saveMetadata}}
+        />
+        <ThemeMetadataField
+          @icon="arrow-left"
+          @label="theme_creator.minimum_discourse_version"
+          @value={{@controller.model.remote_theme.minimum_discourse_version}}
+          @save={{@controller.saveMetadata}}
+        />
+        <ThemeMetadataField
+          @icon="arrow-right"
+          @label="theme_creator.maximum_discourse_version"
+          @value={{@controller.model.remote_theme.maximum_discourse_version}}
+          @save={{@controller.saveMetadata}}
+        />
+      </div>
+
+      {{#unless @controller.model.component}}
         <div class="control-unit">
           <div class="mini-title">
-            {{#if @controller.model.component}}
-              {{i18n "theme_creator.component"}}
-            {{else}}
-              {{i18n "theme_creator.theme"}}
-            {{/if}}
+            {{i18n "admin.customize.theme.color_scheme"}}
           </div>
 
           <div class="description">
-            {{#if @controller.model.component}}
-              {{i18n "theme_creator.is_a_component"}}
-            {{else}}
-              {{i18n "theme_creator.is_a_theme"}}
-            {{/if}}
+            {{i18n "admin.customize.theme.color_scheme_select"}}
           </div>
 
           <div class="control">
-            {{#if @controller.model.component}}
+            <ComboBox
+              @content={{@controller.colorSchemes}}
+              @value={{@controller.colorSchemeId}}
+              @icon="paintbrush"
+              @options={{hash filterable=true}}
+            />
+            {{#if @controller.colorSchemeChanged}}
               <DButton
-                @action={{@controller.switchType}}
-                @label="theme_creator.convert_to_theme"
-                @icon={{@controller.convertIcon}}
-                @title={{@controller.convertTooltip}}
-                class="btn-default btn-normal"
+                @action={{@controller.changeScheme}}
+                @icon="check"
+                class="btn-primary submit-edit"
+              />
+              <DButton
+                @action={{@controller.cancelChangeScheme}}
+                @icon="xmark"
+                class="btn-default cancel-edit"
               />
             {{else}}
+              <LinkTo
+                @route="user.themes.colors"
+                @models={{array
+                  @controller.model.id
+                  @controller.model.color_scheme_id
+                }}
+                @disabled={{@controller.colorSchemeEditDisabled}}
+                title="theme_creator.edit_color_scheme"
+                class="no-text"
+              >
+                {{icon "pencil"}}
+              </LinkTo>
               <DButton
-                @action={{@controller.switchType}}
-                @label="theme_creator.convert_to_component"
-                @icon={{@controller.convertIcon}}
-                @title={{@controller.convertTooltip}}
-                class="btn-default btn-normal"
+                @action={{@controller.destroyColorScheme}}
+                @title="theme_creator.delete_color_scheme"
+                @icon="trash-can"
+                @disabled={{@controller.colorSchemeEditDisabled}}
+                class="btn-danger"
               />
             {{/if}}
           </div>
-        </div>
-
-        <div class="control-unit metadata">
-          <div class="mini-title">
-            {{i18n "theme_creator.metadata"}}
-          </div>
-
-          <ThemeMetadataField
-            @icon="link"
-            @label="theme_creator.about_url"
-            @value={{@controller.model.remote_theme.about_url}}
-            @save={{@controller.saveMetadata}}
-          />
-          <ThemeMetadataField
-            @icon="link"
-            @label="theme_creator.license_url"
-            @value={{@controller.model.remote_theme.license_url}}
-            @save={{@controller.saveMetadata}}
-          />
-          <ThemeMetadataField
-            @icon="users"
-            @label="theme_creator.authors"
-            @value={{@controller.model.remote_theme.authors}}
-            @save={{@controller.saveMetadata}}
-          />
-          <ThemeMetadataField
-            @icon="circle-info"
-            @label="theme_creator.theme_version"
-            @value={{@controller.model.remote_theme.theme_version}}
-            @save={{@controller.saveMetadata}}
-          />
-          <ThemeMetadataField
-            @icon="arrow-left"
-            @label="theme_creator.minimum_discourse_version"
-            @value={{@controller.model.remote_theme.minimum_discourse_version}}
-            @save={{@controller.saveMetadata}}
-          />
-          <ThemeMetadataField
-            @icon="arrow-right"
-            @label="theme_creator.maximum_discourse_version"
-            @value={{@controller.model.remote_theme.maximum_discourse_version}}
-            @save={{@controller.saveMetadata}}
-          />
-        </div>
-
-        {{#unless @controller.model.component}}
-          <div class="control-unit">
-            <div class="mini-title">
-              {{i18n "admin.customize.theme.color_scheme"}}
-            </div>
-
-            <div class="description">
-              {{i18n "admin.customize.theme.color_scheme_select"}}
-            </div>
-
-            <div class="control">
-              <ComboBox
-                @content={{@controller.colorSchemes}}
-                @value={{@controller.colorSchemeId}}
-                @icon="paintbrush"
-                @options={{hash filterable=true}}
-              />
-              {{#if @controller.colorSchemeChanged}}
-                <DButton
-                  @action={{@controller.changeScheme}}
-                  @icon="check"
-                  class="btn-primary submit-edit"
-                />
-                <DButton
-                  @action={{@controller.cancelChangeScheme}}
-                  @icon="xmark"
-                  class="btn-default cancel-edit"
-                />
-              {{else}}
-                <LinkTo
-                  @route="user.themes.colors"
-                  @models={{array
-                    @controller.model.id
-                    @controller.model.color_scheme_id
-                  }}
-                  @disabled={{@controller.colorSchemeEditDisabled}}
-                  title="theme_creator.edit_color_scheme"
-                  class="no-text"
-                >
-                  {{icon "pencil"}}
-                </LinkTo>
-                <DButton
-                  @action={{@controller.destroyColorScheme}}
-                  @title="theme_creator.delete_color_scheme"
-                  @icon="trash-can"
-                  @disabled={{@controller.colorSchemeEditDisabled}}
-                  class="btn-danger"
-                />
-              {{/if}}
-            </div>
-
-            <DButton
-              @action={{@controller.createColorScheme}}
-              @label={{if
-                @controller.creatingColorScheme
-                "theme_creator.adding_color_scheme"
-                "theme_creator.add_color_scheme"
-              }}
-              @icon="plus"
-              @disabled={{@controller.creatingColorScheme}}
-            />
-          </div>
-        {{/unless}}
-
-        <div class="control-unit">
-          <div class="mini-title">
-            {{i18n "admin.customize.theme.css_html"}}
-          </div>
-
-          {{#if @controller.model.hasEditedFields}}
-            <div class="description">
-              {{i18n "admin.customize.theme.custom_sections"}}
-            </div>
-
-            <ul>
-              {{#each @controller.editedFieldsFormatted as |field|}}
-                <li>
-                  {{field}}
-                </li>
-              {{/each}}
-            </ul>
-          {{else}}
-            <div class="description">
-              {{i18n "admin.customize.theme.edit_css_html_help"}}
-            </div>
-          {{/if}}
 
           <DButton
-            @action={{@controller.editTheme}}
-            @label="admin.customize.theme.edit_css_html"
-            class="btn-default edit"
-          />
-        </div>
-
-        <div class="control-unit">
-          <div class="mini-title">
-            {{i18n "admin.customize.theme.uploads"}}
-          </div>
-
-          {{#if @controller.model.uploads}}
-            <ul class="removable-list">
-              {{#each @controller.model.uploads as |upload|}}
-                <li>
-                  <span class="col">
-                    ${{upload.name}}:
-                    <a
-                      href={{upload.url}}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {{upload.filename}}
-                    </a>
-                  </span>
-
-                  <span class="col">
-                    <DButton
-                      @action={{fn @controller.removeUpload upload}}
-                      @icon="xmark"
-                      class="second btn-default cancel-edit"
-                    />
-                  </span>
-                </li>
-              {{/each}}
-            </ul>
-          {{else}}
-            <div class="description">
-              {{i18n "admin.customize.theme.no_uploads"}}
-            </div>
-          {{/if}}
-
-          <DButton
-            @action={{@controller.addUploadModal}}
+            @action={{@controller.createColorScheme}}
+            @label={{if
+              @controller.creatingColorScheme
+              "theme_creator.adding_color_scheme"
+              "theme_creator.add_color_scheme"
+            }}
             @icon="plus"
-            @label="admin.customize.theme.add"
-            class="btn-default"
+            @disabled={{@controller.creatingColorScheme}}
           />
         </div>
+      {{/unless}}
 
-        {{#if @controller.hasSettings}}
-          <div class="control-unit">
-            <div class="mini-title">
-              {{i18n "admin.customize.theme.theme_settings"}}
-            </div>
+      <div class="control-unit">
+        <div class="mini-title">
+          {{i18n "admin.customize.theme.css_html"}}
+        </div>
 
-            <section class="form-horizontal theme settings">
-              {{#each @controller.settings as |setting|}}
-                <UserThemeSettingEditor
-                  @setting={{setting}}
-                  @model={{@controller.model}}
-                  class="theme-setting"
-                />
-              {{/each}}
-            </section>
+        {{#if @controller.model.hasEditedFields}}
+          <div class="description">
+            {{i18n "admin.customize.theme.custom_sections"}}
           </div>
-        {{/if}}
 
-        {{#if @controller.hasTranslations}}
-          <div class="control-unit">
-            <div class="mini-title">
-              {{i18n "admin.customize.theme.theme_translations"}}
-            </div>
-
-            <section class="form-horizontal theme settings translations">
-              {{#each @controller.translations as |translation|}}
-                <UserThemeTranslation
-                  @translation={{translation}}
-                  @model={{@controller.model}}
-                  class="theme-translation"
-                />
-              {{/each}}
-            </section>
-          </div>
-        {{/if}}
-      {{else}}
-        {{#if @controller.hasQuickColorScheme}}
-          <ColorSchemeEditor @colors={{@controller.quickColorScheme.colors}} />
+          <ul>
+            {{#each @controller.editedFieldsFormatted as |field|}}
+              <li>
+                {{field}}
+              </li>
+            {{/each}}
+          </ul>
         {{else}}
-          <div class="control-unit">
-            <DButton
-              @action={{@controller.createColorScheme}}
-              @label={{if
-                @controller.creatingColorScheme
-                "theme_creator.adding_color_scheme"
-                "theme_creator.add_color_scheme"
-              }}
-              @icon="plus"
-              @disabled={{@controller.creatingColorScheme}}
-              class="btn-primary"
-            />
-            <DButton
-              @action={{@controller.showAdvancedAction}}
-              @icon="gear"
-              @label="theme_creator.show_advanced"
-            />
+          <div class="description">
+            {{i18n "admin.customize.theme.edit_css_html_help"}}
           </div>
-        {{/if}}
-      {{/if}}
-      <div class="theme-controls">
-        {{#if @controller.quickColorScheme}}
-          <DButton
-            @action={{@controller.saveQuickColorScheme}}
-            @disabled={{@controller.isSaving}}
-            class="btn-primary"
-          >
-            {{@controller.saveButtonText}}
-          </DButton>
         {{/if}}
 
         <DButton
-          @action={{@controller.shareModal}}
-          @label="theme_creator.share"
-          @icon="users"
-          class="btn-primary"
+          @action={{@controller.editTheme}}
+          @label="admin.customize.theme.edit_css_html"
+          class="btn-default edit"
         />
+      </div>
 
-        {{#if @controller.quickColorScheme}}
+      <div class="control-unit">
+        <div class="mini-title">
+          {{i18n "admin.customize.theme.uploads"}}
+        </div>
+
+        {{#if @controller.model.uploads}}
+          <ul class="removable-list">
+            {{#each @controller.model.uploads as |upload|}}
+              <li>
+                <span class="col">
+                  ${{upload.name}}:
+                  <a
+                    href={{upload.url}}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {{upload.filename}}
+                  </a>
+                </span>
+
+                <span class="col">
+                  <DButton
+                    @action={{fn @controller.removeUpload upload}}
+                    @icon="xmark"
+                    class="second btn-default cancel-edit"
+                  />
+                </span>
+              </li>
+            {{/each}}
+          </ul>
+        {{else}}
+          <div class="description">
+            {{i18n "admin.customize.theme.no_uploads"}}
+          </div>
+        {{/if}}
+
+        <DButton
+          @action={{@controller.addUploadModal}}
+          @icon="plus"
+          @label="admin.customize.theme.add"
+          class="btn-default"
+        />
+      </div>
+
+      {{#if @controller.hasSettings}}
+        <div class="control-unit">
+          <div class="mini-title">
+            {{i18n "admin.customize.theme.theme_settings"}}
+          </div>
+
+          <section class="form-horizontal theme settings">
+            {{#each @controller.settings as |setting|}}
+              <UserThemeSettingEditor
+                @setting={{setting}}
+                @model={{@controller.model}}
+                class="theme-setting"
+              />
+            {{/each}}
+          </section>
+        </div>
+      {{/if}}
+
+      {{#if @controller.hasTranslations}}
+        <div class="control-unit">
+          <div class="mini-title">
+            {{i18n "admin.customize.theme.theme_translations"}}
+          </div>
+
+          <section class="form-horizontal theme settings translations">
+            {{#each @controller.translations as |translation|}}
+              <UserThemeTranslation
+                @translation={{translation}}
+                @model={{@controller.model}}
+                class="theme-translation"
+              />
+            {{/each}}
+          </section>
+        </div>
+      {{/if}}
+    {{else}}
+      {{#if @controller.hasQuickColorScheme}}
+        <ColorSchemeEditor @colors={{@controller.quickColorScheme.colors}} />
+      {{else}}
+        <div class="control-unit">
+          <DButton
+            @action={{@controller.createColorScheme}}
+            @label={{if
+              @controller.creatingColorScheme
+              "theme_creator.adding_color_scheme"
+              "theme_creator.add_color_scheme"
+            }}
+            @icon="plus"
+            @disabled={{@controller.creatingColorScheme}}
+            class="btn-primary"
+          />
           <DButton
             @action={{@controller.showAdvancedAction}}
             @icon="gear"
             @label="theme_creator.show_advanced"
           />
-        {{else if @controller.showAdvanced}}
-          <DButton
-            @action={{routeAction "editLocalModal"}}
-            @icon="pencil"
-            @label="theme_creator.edit_local"
-          />
-        {{/if}}
+        </div>
+      {{/if}}
+    {{/if}}
+    <div class="theme-controls">
+      {{#if @controller.quickColorScheme}}
+        <DButton
+          @action={{@controller.saveQuickColorScheme}}
+          @disabled={{@controller.isSaving}}
+          class="btn-primary"
+        >
+          {{@controller.saveButtonText}}
+        </DButton>
+      {{/if}}
 
-        {{#unless @controller.hidePreview}}
-          <a
-            href={{@controller.previewUrl}}
-            title={{i18n "theme_creator.explain_preview"}}
-            target="_blank"
-            rel="noopener noreferrer"
-            class="btn btn-icon-text"
-          >
-            {{icon "desktop"}}
-            <span class="d-button-label">
-              {{i18n "theme_creator.preview"}}
-            </span>
-          </a>
-        {{/unless}}
+      <DButton
+        @action={{@controller.shareModal}}
+        @label="theme_creator.share"
+        @icon="users"
+        class="btn-primary"
+      />
 
+      {{#if @controller.quickColorScheme}}
+        <DButton
+          @action={{@controller.showAdvancedAction}}
+          @icon="gear"
+          @label="theme_creator.show_advanced"
+        />
+      {{else if @controller.showAdvanced}}
+        <DButton
+          @action={{routeAction "editLocalModal"}}
+          @icon="pencil"
+          @label="theme_creator.edit_local"
+        />
+      {{/if}}
+
+      {{#unless @controller.hidePreview}}
         <a
-          href={{@controller.downloadUrl}}
+          href={{@controller.previewUrl}}
+          title={{i18n "theme_creator.explain_preview"}}
           target="_blank"
           rel="noopener noreferrer"
           class="btn btn-icon-text"
         >
-          {{icon "download"}}
-          {{i18n "admin.export_json.button_text"}}
+          {{icon "desktop"}}
+          <span class="d-button-label">
+            {{i18n "theme_creator.preview"}}
+          </span>
         </a>
+      {{/unless}}
 
-        <DButton
-          @action={{@controller.destroy}}
-          @label="theme_creator.delete"
-          @icon="trash-can"
-          class="btn-danger"
-        />
-      </div>
+      <a
+        href={{@controller.downloadUrl}}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="btn btn-icon-text"
+      >
+        {{icon "download"}}
+        {{i18n "admin.export_json.button_text"}}
+      </a>
+
+      <DButton
+        @action={{@controller.destroy}}
+        @label="theme_creator.delete"
+        @icon="trash-can"
+        class="btn-danger"
+      />
     </div>
-  </template>
-);
+  </div>
+</template>

--- a/assets/javascripts/discourse/templates/user/themes/show/schema.gjs
+++ b/assets/javascripts/discourse/templates/user/themes/show/schema.gjs
@@ -1,33 +1,27 @@
 import { hash } from "@ember/helper";
 import { LinkTo } from "@ember/routing";
-import RouteTemplate from "ember-route-template";
 import icon from "discourse/helpers/d-icon";
 import { i18n } from "discourse-i18n";
 import UserSchemaThemeSettingEditor from "../../../../components/user-schema-theme-setting-editor";
 
-export default RouteTemplate(
-  <template>
-    <div class="customize-themes-show-schema__header row">
-      <LinkTo
-        @route="user.themes.show"
-        @model={{@model.theme.id}}
-        class="btn-transparent customize-themes-show-schema__back"
-      >
-        {{icon "arrow-left"}}{{@model.theme.name}}
-      </LinkTo>
-      <h2>
-        {{i18n
-          "admin.customize.schema.title"
-          (hash name=@model.setting.setting)
-        }}
-      </h2>
-    </div>
+export default <template>
+  <div class="customize-themes-show-schema__header row">
+    <LinkTo
+      @route="user.themes.show"
+      @model={{@model.theme.id}}
+      class="btn-transparent customize-themes-show-schema__back"
+    >
+      {{icon "arrow-left"}}{{@model.theme.name}}
+    </LinkTo>
+    <h2>
+      {{i18n "admin.customize.schema.title" (hash name=@model.setting.setting)}}
+    </h2>
+  </div>
 
-    <UserSchemaThemeSettingEditor
-      @id={{@model.theme.id}}
-      @routeToRedirect="user.themes.show"
-      @schema={{@model.setting.objects_schema}}
-      @setting={{@model.setting}}
-    />
-  </template>
-);
+  <UserSchemaThemeSettingEditor
+    @id={{@model.theme.id}}
+    @routeToRedirect="user.themes.show"
+    @schema={{@model.setting.objects_schema}}
+    @setting={{@model.setting}}
+  />
+</template>

--- a/spec/system/user_themes_spec.rb
+++ b/spec/system/user_themes_spec.rb
@@ -14,9 +14,7 @@ RSpec.describe "User themes" do
 
     find(".btn-default.edit").click
 
-    expect(page).to have_current_path(
-      %r{/u/#{user.username}/themes/#{theme.id}/common/scss/edit},
-    )
+    expect(page).to have_current_path(%r{/u/#{user.username}/themes/#{theme.id}/common/scss/edit})
     expect(page).to have_css(".current-style")
   end
 

--- a/spec/system/user_themes_spec.rb
+++ b/spec/system/user_themes_spec.rb
@@ -3,6 +3,23 @@
 RSpec.describe "User themes" do
   before { enable_current_plugin }
 
+  it "can open the code editor from a theme's show page" do
+    user = Fabricate(:user)
+    theme = Fabricate(:theme, user: user)
+    theme.set_field(target: :common, name: :scss, value: "body { color: red; }")
+    theme.save!
+
+    sign_in(user)
+    visit "/u/#{user.username}/themes/#{theme.id}"
+
+    find(".btn-default.edit").click
+
+    expect(page).to have_current_path(
+      %r{/u/#{user.username}/themes/#{theme.id}/common/scss/edit},
+    )
+    expect(page).to have_css(".current-style")
+  end
+
   it "can navigate to the user themes page and create a theme" do
     user = Fabricate(:user)
     sign_in(user)


### PR DESCRIPTION
The Edit Code button threw `TypeError: this.class.create is not a function` because the edit controller was importing from the old flat path `admin/controllers/admin-customize-themes-edit`, which no longer exists after admin code changes.

- Updated all `admin/...` imports to use the correct `discourse/admin/...` prefix
- Updated the edit route's `templateName`
- Removed `RouteTemplate` wrappers from route templates.