### PR TITLE
FIX: update html builder for EmberCli -> EmberAssets rename

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -22,7 +22,7 @@ after_initialize do
   # so we need to load it for non-staff users.
   register_html_builder("server:before-head-close") do |ctx|
     admin_scripts =
-      EmberCli.script_chunks["chunk.admin"]&.map do |script_name|
+      ::EmberAssets.script_chunks["admin"]&.map do |script_name|
         "<link rel='preload' href='#{ctx.helpers.script_asset_path(script_name)}' as='script' nonce='#{ctx.helpers.csp_nonce_placeholder}' data-discourse-entrypoint='admin'>"
       end || []
 


### PR DESCRIPTION
Discourse core renamed the EmberCli class to EmberAssets (lib/ember_assets.rb)
and keys script_chunks by entrypoint name, so EmberCli.script_chunks["chunk.admin"]
raised `uninitialized constant EmberCli` on every server render. Because the
"server:before-head-close" builder runs on every page, this turned all responses
into 500s, breaking both the controller specs (the expected 403/404 error pages
also invoke the builder) and the system specs.

Use EmberAssets.script_chunks["admin"] to match core's current API.