### PR TITLE
FIX: Restore the theme creator on current Discourse core

### DIFF
--- a/lib/theme_creator/application_helper_extension.rb
+++ b/lib/theme_creator/application_helper_extension.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ThemeCreator
+  module ApplicationHelperExtension
+    extend ActiveSupport::Concern
+
+    def client_side_setup_data
+      super.merge(is_staff: true)
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,12 +17,13 @@ require_relative "lib/theme_creator/engine"
 after_initialize do
   require_relative "app/jobs/scheduled/cleanup_topics"
   require_relative "lib/theme_creator/application_controller_extension"
+  require_relative "lib/theme_creator/application_helper_extension"
 
   # We're re-using a lot of locale strings from the admin section
   # so we need to load it for non-staff users.
   register_html_builder("server:before-head-close") do |ctx|
     admin_scripts =
-      EmberCli.script_chunks["chunk.admin"]&.map do |script_name|
+      EmberAssets.script_chunks["admin/compat-modules"]&.map do |script_name|
         "<link rel='preload' href='#{ctx.helpers.script_asset_path(script_name)}' as='script' nonce='#{ctx.helpers.csp_nonce_placeholder}' data-discourse-entrypoint='admin'>"
       end || []
 
@@ -156,6 +157,7 @@ after_initialize do
 
   reloadable_patch do |plugin|
     ApplicationController.prepend(ThemeCreator::ApplicationControllerExtension)
+    ApplicationHelper.prepend(ThemeCreator::ApplicationHelperExtension)
   end
 
   add_user_api_key_scope(


### PR DESCRIPTION
## What

Recent core JS build changes broke the theme creator in two ways. This fixes both — with no companion core change required.

### 1. 500 on every page (`EmberCli` removed)

`plugin.rb` referenced the `EmberCli` constant, which core renamed to `EmberAssets` and removed (with no alias) in discourse/discourse#40938.

The `server:before-head-close` HTML builder runs on every full application-layout render, so once a build containing that rename was deployed, every browser request raised:

```
ActionView::Template::Error (uninitialized constant Plugin::Instance::EmberCli)
plugins/discourse-theme-creator/plugin.rb:25
```

and returned a 500. Crawler/bot requests skip this builder, which is why they kept returning 200.

Reported at https://meta.discourse.org/t/theme-creator-is-responding-with-500/406027.

**Fix:** swap `EmberCli` for `EmberAssets`. `script_chunks` is unchanged on the renamed class, so it's a drop-in replacement — the same change core made in `app/views/layouts/application.html.erb`.

### 2. Theme editor failed to load for non-staff users

The same builder preloads the admin scripts the theme editor reuses. It looked them up via `script_chunks["chunk.admin"]`, but the Rolldown build (discourse/discourse#35963) renamed that chunk to `admin/compat-modules`, so the lookup returned nil.

More fundamentally, after the Rolldown migration core only registers the `discourse/admin/*` modules at boot when the current user is staff — `discourse.js` gates `loadAdmin()` on `#data-discourse-setup[data-is-staff="true"]`. For a non-staff (or anonymous) visitor those modules are never defined, so the theme-creator bundle — which statically imports them and is loaded for everyone — throws `Could not find module "discourse/admin/..."` and the whole plugin fails to load.

**Fix:** use the current chunk name, and make the server render `data-is-staff="true"` for every request so core's existing, unmodified boot gate loads the admin bundle for us. We prepend `ApplicationHelper#client_side_setup_data` and merge `is_staff: true` into the setup hash serialised into the `#data-discourse-setup` meta tag. Because the value is rendered server-side from the first byte, there is no DOM mutation, no extra inline `<script>`, and no dependency on script execution order.

Why this is safe:

- `#data-discourse-setup[data-is-staff]` has exactly one consumer in core: the boot gate in `discourse.js`. Real staff status comes from the preloaded `currentUser` JSON, so forcing the flag only affects admin-bundle loading and grants no actual staff/admin privileges — admin routes and endpoints stay guarded server-side by `AdminConstraint` and `Guardian`.
- We override `client_side_setup_data` specifically, not the `staff?` helper, so only `is_staff` changes. `disable_custom_css` (driven by `loading_admin?`) and the admin asset/locale preloads are untouched, so theme preview keeps rendering custom CSS as before.
- The flag is emitted for every request, since the plugin bundle loads for all visitors (including anonymous, via the public theme-share routes) and eagerly imports the admin modules.

> **Note:** this is the "monkey-patch" alternative to discourse/discourse#41298, which instead teaches `discourse.js` to honour the `data-discourse-entrypoint="admin"` preload marker. This approach keeps core's boot gate narrow and plugin-agnostic, at the cost of monkey-patching a core helper and setting a semantically false `is_staff` flag — and, crucially, needs no core change to ship.

## Testing

The plugin's backend and system test suites pass, and the theme editor loads for non-staff (and anonymous) users again.
