### PR TITLE
FIX: Load admin bundle for non-staff without a core change

### DIFF
--- a/lib/theme_creator/application_helper_extension.rb
+++ b/lib/theme_creator/application_helper_extension.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module ThemeCreator
+  module ApplicationHelperExtension
+    extend ActiveSupport::Concern
+
+    def client_side_setup_data
+      super.merge(is_staff: true)
+    end
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -17,6 +17,7 @@ require_relative "lib/theme_creator/engine"
 after_initialize do
   require_relative "app/jobs/scheduled/cleanup_topics"
   require_relative "lib/theme_creator/application_controller_extension"
+  require_relative "lib/theme_creator/application_helper_extension"
 
   # We're re-using a lot of locale strings from the admin section
   # so we need to load it for non-staff users.
@@ -156,6 +157,7 @@ after_initialize do
 
   reloadable_patch do |plugin|
     ApplicationController.prepend(ThemeCreator::ApplicationControllerExtension)
+    ApplicationHelper.prepend(ThemeCreator::ApplicationHelperExtension)
   end
 
   add_user_api_key_scope(


### PR DESCRIPTION
## What

The theme editor lets non-staff users edit their own themes and reuses a number of `discourse/admin/*` modules to do it. After the Rolldown migration, core only registers those modules at boot when the current user is staff — `discourse.js` gates `loadAdmin()` on `#data-discourse-setup[data-is-staff="true"]`. For a non-staff (or anonymous) visitor the admin modules are never defined, so the theme-creator bundle — which statically imports them and is loaded for everyone — throws `Could not find module "discourse/admin/..."` and the whole plugin fails to load.

## Approach

This is the **"monkey-patch" alternative** to the core change in discourse/discourse#41298 (which teaches `discourse.js` to also honour the `data-discourse-entrypoint="admin"` preload marker). Instead of changing core, the plugin makes the server render `data-is-staff="true"` for every request, so core's existing, unmodified gate loads the admin bundle for us.

We prepend `ApplicationHelper#client_side_setup_data` and merge `is_staff: true` into the setup hash that gets serialised into the `#data-discourse-setup` meta tag:

```ruby
module ThemeCreator
  module ApplicationHelperExtension
    extend ActiveSupport::Concern

    def client_side_setup_data
      super.merge(is_staff: true)
    end
  end
end
```

Because the value is rendered server-side from the first byte, there is no DOM mutation, no extra inline `<script>`, and no dependency on classic-vs-module script execution order. (This supersedes the earlier `server:after-body-open` inline-script version of this PR.)

### Why it's safe / why it works

- **Isolated** — `#data-discourse-setup[data-is-staff]` has exactly one consumer in core: the boot gate in `discourse.js`. Real staff status comes from the preloaded `currentUser` JSON, so forcing the flag only affects admin-bundle loading and grants **no** actual staff/admin privileges. Admin routes and endpoints stay guarded server-side by `AdminConstraint` and `Guardian`.
- **Surgical** — we override `client_side_setup_data`, not the `staff?` helper, so only `is_staff` changes. `disable_custom_css` (driven by `loading_admin?`) and the admin asset/locale preloads are untouched, so theme preview keeps rendering custom CSS as before.
- **Unconditional** — the flag is emitted for every request, not just staff or logged-in ones. The plugin bundle is loaded for all visitors and eagerly imports admin, and its public theme-share routes serve anonymous users, so admin has to be registered for everyone — otherwise the bundle throws for anon.

## Trade-off vs. the core change (#41298)

This keeps core's boot gate narrow and plugin-agnostic — the unusual behaviour is fully contained in the plugin — at the cost of monkey-patching a core helper and setting a semantically false `is_staff` flag. #41298 is more explicit and testable in core, but bakes awareness of this plugin's needs into the boot path.

## Testing

- Plugin system specs: `23 examples, 0 failures` against **unmodified** core (no #41298).
- Verified in a real browser: anonymous and logged-in non-staff both boot the plugin + admin with zero module errors; real `currentUser` stays `{ admin: false, moderator: false, staff: false }` and `/admin` still returns 404 (no privilege granted).

---

Stacked on #138 (the `EmberAssets` fix + admin preloads); base will retarget to `main` when that merges.
